### PR TITLE
Harden conversion script diagnostics

### DIFF
--- a/Tools/ruby/combine_yaml.rb
+++ b/Tools/ruby/combine_yaml.rb
@@ -4,6 +4,7 @@
 #Combines yaml files
 
 require 'optparse'
+require 'fileutils'
 require 'yaml'
 
 # Useful functions I wish hashes had..
@@ -40,16 +41,45 @@ optparser = OptionParser.new do |opts|
   end
 end
 
-optparser.parse!
+begin
+  optparser.parse!
+rescue OptionParser::ParseError => e
+  abort "combine_yaml: #{e.message}"
+end
 
 input_files = ARGV
 
 if $input
-  input_files = IO.readlines($input).map{|f| f.gsub('\\', '/').chomp }
+  abort "combine_yaml: input list not found: #{$input}" if !File.file?($input)
+
+  input_files = IO.readlines($input).map{|f| f.gsub('\\', '/').chomp }.reject(&:empty?)
 end
 
-input_yaml  = input_files.map {|f| data = YAML.load(File.read(f)) }
+def load_yaml_file(filename)
+  abort "combine_yaml: input file not found: #{filename}" if !File.file?(filename)
+
+  data = YAML.load(File.read(filename))
+  abort "combine_yaml: input file must be a YAML mapping: #{filename}" if !data.is_a?(Hash)
+
+  data
+rescue Psych::Exception => e
+  abort "combine_yaml: invalid YAML in #{filename}: #{e.message}"
+rescue SystemCallError => e
+  abort "combine_yaml: unable to read #{filename}: #{e.message}"
+end
+
+input_yaml  = input_files.map {|f| load_yaml_file(f) }
 merged_hash = input_yaml.inject({}) { |merged, input| merged.deep_merge input }
 
-out_stream = $out ? File.open($out, 'w') : $stdout
-out_stream.puts merged_hash.to_yaml
+if $out
+  output_dir = File.dirname($out)
+  FileUtils.mkdir_p(output_dir) if output_dir && output_dir != '.'
+end
+
+begin
+  out_stream = $out ? File.open($out, 'w') : $stdout
+  out_stream.puts merged_hash.to_yaml
+  out_stream.close if $out
+rescue SystemCallError => e
+  abort "combine_yaml: unable to write #{$out}: #{e.message}"
+end

--- a/Tools/ruby/expand_erb.rb
+++ b/Tools/ruby/expand_erb.rb
@@ -30,8 +30,21 @@ optparser = OptionParser.new do |opts|
   end
 end
 
-optparser.parse!
-raise "ERROR: No input file specified!" if ARGV.length != 1
+begin
+  optparser.parse!
+rescue OptionParser::ParseError => e
+  abort "expand_erb: #{e.message}"
+end
+
+abort "expand_erb: expected exactly one input file" if ARGV.length != 1
+
+SRC = ARGV[0]
+
+abort "expand_erb: input file not found: #{SRC}" if !File.file?(SRC)
+
+$options[:require_dirs].each do |dir|
+  abort "expand_erb: require directory not found: #{dir}" if !File.directory?(dir)
+end
 
 $options[:require_dirs].each do |dir|
   $LOAD_PATH << dir
@@ -40,14 +53,17 @@ $options[:require_dirs].each do |dir|
   end
 end
 
-SRC = ARGV[0]
+begin
+  content = File.open(SRC, 'r') { |f| ERB.new(f.read).result }
 
-content = File.open(SRC, 'r') { |f| ERB.new(f.read).result }
+  if $options[:output]
+    output_dir = File.dirname($options[:output])
+    FileUtils.mkdir_p(output_dir) if output_dir && output_dir != '.'
+  end
 
-FileUtils.mkdir_p(File.dirname($options[:output])) if $options[:output]
-out_stream = $options[:output] ? File.open($options[:output], "w") : $stdout
-out_stream.print content
-
-if $options[:output]
-  out_stream.close
+  out_stream = $options[:output] ? File.open($options[:output], "w") : $stdout
+  out_stream.print content
+  out_stream.close if $options[:output]
+rescue StandardError => e
+  abort "expand_erb: #{SRC}: #{e.message}"
 end

--- a/Tools/ruby/maya2pb.rb
+++ b/Tools/ruby/maya2pb.rb
@@ -4,6 +4,7 @@
 # Convert a YAML file with instance data to a protocol buffer file
 
 require 'optparse'
+require 'fileutils'
 require 'yaml'
 require 'zlib'
 
@@ -18,6 +19,12 @@ require 'Engine/Scene/Model/InstanceSet.pb.rb'
 ##################
 
 options = {}
+
+def fail_with_message(message, option_parser = nil)
+  warn message
+  warn option_parser if option_parser
+  exit 1
+end
 
 option_parser = OptionParser.new do |opts|
   opts.banner = "Usage: read_instance.rb -o output_file input_file"
@@ -39,17 +46,46 @@ end
 
 Tracker::addDepfileOption(options, option_parser)
 
-option_parser.parse!
-
-Tracker::writeDependenciesFile(options, options[:output]) if options[:output]
+begin
+  option_parser.parse!
+rescue OptionParser::ParseError => e
+  fail_with_message("ERROR: #{e.message}", option_parser)
+end
 
 if ARGV.length != 1
-  raise "ERROR: No YAML input file specified!"
+  fail_with_message("ERROR: Expected exactly one YAML input file, got #{ARGV.length}.", option_parser)
 end
 
 ##################
 # functions      #
 ##################
+
+def ensure_output_directory(filename)
+  output_dir = File.dirname(filename)
+  return if output_dir.nil? || output_dir == '.'
+
+  FileUtils.mkdir_p(output_dir)
+rescue SystemCallError => e
+  fail_with_message("ERROR: Could not create output directory '#{output_dir}' for '#{filename}': #{e.message}")
+end
+
+def load_yaml_file(filename)
+  YAML.load(File.read(filename))
+rescue Psych::Exception => e
+  fail_with_message("ERROR: Could not parse YAML file '#{filename}': #{e.message}")
+rescue SystemCallError => e
+  fail_with_message("ERROR: Could not read YAML file '#{filename}': #{e.message}")
+end
+
+def validate_root_node(data, filename)
+  if !data.is_a?(Array)
+    fail_with_message("ERROR: Root node in '#{filename}' should be an array.")
+  end
+
+  if data.empty? || data.any? { |group| !group.is_a?(Hash) }
+    fail_with_message("ERROR: Root node in '#{filename}' should be a non-empty array of mappings.")
+  end
+end
 
 def create_vector(node)
   return Usg::Vector3f.new(x: node[0], y: node[1], z: node[2])
@@ -112,10 +148,18 @@ class FileWriter
   MESSAGE_DELIMITER = "\0"
 
   def self.write(header, sets, options = {})
-    out = options[:output] ? File.open(options[:output], "wb") : STDOUT
+    if options[:output]
+      ensure_output_directory(options[:output])
+      out = File.open(options[:output], "wb")
+    else
+      out = STDOUT
+    end
+
     header.serialize(out) << MESSAGE_DELIMITER
     sets.each { |s| s.serialize(out) << MESSAGE_DELIMITER }
     out.close if options[:output]
+  rescue SystemCallError => e
+    fail_with_message("ERROR: Could not write output file '#{options[:output]}': #{e.message}")
   end
 end
 
@@ -124,11 +168,13 @@ end
 ##################
 
 YAML_FILE = ARGV[0]
-data = YAML.load(File.read(YAML_FILE))
-raise "Root node should be an array" if not data.is_a? Array
+data = load_yaml_file(YAML_FILE)
+validate_root_node(data, YAML_FILE)
 
 if data[0]['Instance'] == true
   process_as_instances(data, options)
 else
   process_as_points(data, options)
 end
+
+Tracker::writeDependenciesFile(options, options[:output]) if options[:output]

--- a/Tools/ruby/nameDataHashListGen.rb
+++ b/Tools/ruby/nameDataHashListGen.rb
@@ -2,6 +2,66 @@
 require 'optparse'
 require 'zlib'
 require 'digest/sha1'
+require 'fileutils'
+
+MESSAGE_DELIMITER = "\0"
+
+def abort_with_error(message)
+  $stderr.puts "ERROR: #{message}"
+  exit 1
+end
+
+def validate_readable_file(path, description)
+  abort_with_error("#{description} not specified") if path.nil? || path.empty?
+  abort_with_error("#{description} does not exist: #{path}") unless File.exist?(path)
+  abort_with_error("#{description} is not a file: #{path}") unless File.file?(path)
+  abort_with_error("#{description} is not readable: #{path}") unless File.readable?(path)
+end
+
+def validate_directory(path, description)
+  abort_with_error("#{description} not specified") if path.nil? || path.empty?
+  abort_with_error("#{description} does not exist: #{path}") unless File.exist?(path)
+  abort_with_error("#{description} is not a directory: #{path}") unless File.directory?(path)
+end
+
+def create_output_parent(output)
+  abort_with_error("Output filename not specified") if output.nil? || output.empty?
+
+  parent = File.dirname(output)
+  return if parent.nil? || parent.empty? || parent == '.'
+
+  if File.exist?(parent)
+    abort_with_error("Output parent is not a directory: #{parent}") unless File.directory?(parent)
+    return
+  end
+
+  FileUtils.mkdir_p(parent)
+rescue SystemCallError => e
+  abort_with_error("Could not create output directory #{parent}: #{e.message}")
+end
+
+def validate_listed_data_files(input, dir)
+  current_path = input
+  File.foreach(input) do |line|
+    file_name = line.chomp
+    current_path = File.join(dir, file_name)
+    validate_readable_file(current_path, "Listed data file")
+    File.open(current_path, 'rb') {}
+  end
+rescue SystemCallError => e
+  abort_with_error("Could not read file #{current_path}: #{e.message}")
+end
+
+def require_protobufs(require_dirs)
+  require_dirs.each do |dir|
+    $LOAD_PATH << dir
+    Dir[File.join(dir, '**', '*.pb.rb')].each do |f|
+      require f.sub(%r{\A#{Regexp.escape(dir)}[\\/]}, '')
+    end
+  end
+rescue LoadError => e
+  abort_with_error("Could not require protobuf file: #{e.message}")
+end
 
 ##################
 # option parsing #
@@ -33,41 +93,51 @@ option_parser = OptionParser.new do |opts|
   end
 end
 
-option_parser.parse!
-
-if ARGV.length != 1
-  raise "ERROR: No YAML input file specified!"
+begin
+  option_parser.parse!
+rescue OptionParser::ParseError => e
+  abort_with_error(e.message)
 end
 
-# Require PB codes
+abort_with_error("Expected exactly one input list file") if ARGV.length != 1
+
+input = ARGV[0]
+
+abort_with_error("Output filename not specified") if options[:output].nil? || options[:output].empty?
+abort_with_error("Root directory not specified") if options[:dir].nil? || options[:dir].empty?
+
+validate_directory(options[:dir], "Root directory")
 options[:require_dirs].each do |dir|
-  $LOAD_PATH << dir
-  Dir[dir + "/**/*.pb.rb"].each do |f|
-    require f.sub(dir + "/", "")
-  end
+  validate_directory(dir, "Require directory")
 end
 
-MESSAGE_DELIMITER = "\0"
+validate_readable_file(input, "Input list")
+validate_listed_data_files(input, options[:dir])
+create_output_parent(options[:output])
+
+# Require PB codes after all require directories have been validated.
+require_protobufs(options[:require_dirs])
 
 def main(output, input, dir)
   list = []
 
-  f = File.open( input, 'r' )
-  f.each {|line|
-    fileName = "#{line[0..-2]}"
-    filePath = "#{dir}/#{fileName}"
-    crc = Zlib.crc32(fileName, 0)
-    # dataHash = Digest::SHA1.hexdigest(File.open(filePath, "rb").read)
-    dataHash = Zlib.crc32(File.open(filePath, "rb").read, 0)
-    # print "#{filePath} #{crc} #{dataHash}\n"
+  File.open( input, 'r' ) do |f|
+    f.each {|line|
+      fileName = line.chomp
+      filePath = "#{dir}/#{fileName}"
+      crc = Zlib.crc32(fileName, 0)
+      # dataHash = Digest::SHA1.hexdigest(File.open(filePath, "rb").read)
+      dataHash = Zlib.crc32(File.open(filePath, "rb").read, 0)
+      # print "#{filePath} #{crc} #{dataHash}\n"
 
-    temp = {}
-    temp[:name] = fileName
-    temp[:crc] = crc
-    temp[:dataHash] = dataHash
+      temp = {}
+      temp[:name] = fileName
+      temp[:crc] = crc
+      temp[:dataHash] = dataHash
 
-    list.push( temp )
-  }
+      list.push( temp )
+    }
+  end
 
   list.sort! {|a, b|
     a[:crc] <=> b[:crc]
@@ -83,10 +153,15 @@ def main(output, input, dir)
 
   header = Usg::NameDataHashHeader.new( hashNum: list.length )
 
-  out = File.open(output, "wb")
-  header.serialize(out) << MESSAGE_DELIMITER
-  messages.each { |s| s.serialize(out) << MESSAGE_DELIMITER }
-  out.close
+  begin
+    out = File.open(output, "wb")
+    header.serialize(out) << MESSAGE_DELIMITER
+    messages.each { |s| s.serialize(out) << MESSAGE_DELIMITER }
+    out.close
+  rescue SystemCallError => e
+    out.close if out && !out.closed?
+    abort_with_error("Could not write output file #{output}: #{e.message}")
+  end
 end
 
-main(options[:output], ARGV[0], options[:dir])
+main(options[:output], input, options[:dir])

--- a/Tools/ruby/process_hierarchy.rb
+++ b/Tools/ruby/process_hierarchy.rb
@@ -6,6 +6,7 @@
 # relationships for each entity are also written to this file.
 
 require 'erb'
+require 'fileutils'
 require 'matrix'
 require 'optparse'
 require 'pathname'
@@ -60,8 +61,30 @@ optparser = OptionParser.new do |opts|
   end
 end
 
-optparser.parse!
-raise "ERROR: No input file specified!" if ARGV.length != 1
+begin
+  optparser.parse!
+rescue OptionParser::ParseError => e
+  abort "process_hierarchy: #{e.message}"
+end
+
+abort "process_hierarchy: expected exactly one input file" if ARGV.length != 1
+
+ENTITY_SRC = ARGV[0]
+
+abort "process_hierarchy: input file not found: #{ENTITY_SRC}" if !File.file?(ENTITY_SRC)
+
+$options[:defaults].each do |filename|
+  abort "process_hierarchy: defaults file not found: #{filename}" if !File.file?(filename)
+end
+
+$options[:require_dirs].each do |dir|
+  abort "process_hierarchy: require directory not found: #{dir}" if !File.directory?(dir)
+end
+
+if $options[:output]
+  output_dir = File.dirname($options[:output])
+  FileUtils.mkdir_p(output_dir) if output_dir && output_dir != '.'
+end
 
 $options[:require_dirs].each do |dir|
   $LOAD_PATH << dir
@@ -77,8 +100,6 @@ require_relative 'lib/matrix_util'
 require_relative 'lib/skeletonextractor'
 require_relative 'lib/componentextractor'
 require_relative 'tracker'
-
-ENTITY_SRC = ARGV[0]
 
 # Useful function I wish hashes had.. should probably go in some utility file somewhere
 class ::Hash
@@ -154,6 +175,31 @@ def symbolize_keys(hash)
   end
 end
 
+def load_yaml_file(filename, description)
+  content = File.open(filename, 'r') { |f| ERB.new(f.read).result }
+  YAML.load(content)
+rescue Psych::Exception => e
+  raise "#{description} has invalid YAML: #{e.message}"
+rescue SystemCallError => e
+  raise "#{description} could not be read: #{e.message}"
+end
+
+def validate_entity_yaml(data, description)
+  return if data.is_a?(Hash)
+
+  if data.is_a?(Array)
+    raise "#{description} must contain at least one entity" if data.empty?
+
+    data.each_with_index do |entry, i|
+      raise "#{description} entity #{i + 1} must be a YAML mapping" if !entry.is_a?(Hash)
+    end
+
+    return
+  end
+
+  raise "#{description} must be a YAML mapping or non-empty list of mappings"
+end
+
 def find_include(entity_name)
     relative_path = $options[:includes].find do |i|
       path = File.join(i, entity_name + ".yml")
@@ -166,6 +212,8 @@ def find_include(entity_name)
 end
 
 def import(data, entity_name, already_loaded, override_data)
+  raise "entity '#{entity_name}' must be a YAML mapping" if !data.is_a?(Hash)
+
   if !already_loaded.has_key? entity_name
     already_loaded[entity_name] = :loading
     e = symbolize_keys(data)
@@ -186,8 +234,7 @@ def import(data, entity_name, already_loaded, override_data)
     inherits_from.each do |inherited_entity|
       filename = find_include(inherited_entity)
       Tracker::DepSet.instance.addDep(filename)
-      content = File.open(filename, 'r') { |f| ERB.new(f.read).result }
-      inherited_data << import(YAML.load(content), File.basename(filename, '.yml'), already_loaded, override_data)
+      inherited_data << import(load_yaml_file(filename, "included entity '#{inherited_entity}'"), File.basename(filename, '.yml'), already_loaded, override_data)
     end
 
     override_data.each_pair do |name, data|
@@ -205,10 +252,9 @@ end
 
 if $options[:defaults]
   $defaults = $options[:defaults].inject({}) do |acc, filename|
-    File.open(filename , 'r') do |f|
-      content = ERB.new(f.read).result
-      acc.deep_merge(symbolize_keys( YAML.load(content) ))
-    end
+    defaults = load_yaml_file(filename, "defaults file '#{filename}'")
+    raise "defaults file '#{filename}' must be a YAML mapping" if !defaults.is_a?(Hash)
+    acc.deep_merge(symbolize_keys(defaults))
   end
 end
 
@@ -392,6 +438,10 @@ end
 
 def write_file(entities)
   header = Usg::HierarchyHeader.new(entityCount: entities.length)
+  if $options[:output]
+    output_dir = File.dirname($options[:output])
+    FileUtils.mkdir_p(output_dir) if output_dir && output_dir != '.'
+  end
   out_stream = $options[:output] ? File.open($options[:output], "wb") : $stdout
   out_stream.binmode
   header.serialize(out_stream) << Constants::NUL
@@ -399,25 +449,29 @@ def write_file(entities)
   out_stream.close if $options[:output]
 end
 
-content = File.open(ENTITY_SRC, 'r') { |f| ERB.new(f.read).result }
-data = YAML.load(content)
-entities = []
+begin
+  data = load_yaml_file(ENTITY_SRC, "input file '#{ENTITY_SRC}'")
+  validate_entity_yaml(data, "input file '#{ENTITY_SRC}'")
+  entities = []
 
-if data.is_a? Hash
-  # the file contains a single entity
-  entity_name = get_unique_name(data)
-  entities<< process_entity(data, entity_name)
-elsif data.is_a? Array
-  # the file contains a list of entities
-  data.each do |entity_data|
-    $already_loaded = {}
-    # clear the set of identifiers, becuause each node should
-    # be processed independently
-    $identifiers.clear
-    entities << process_entity(entity_data, 'Placeholder')
+  if data.is_a? Hash
+    # the file contains a single entity
+    entity_name = get_unique_name(data)
+    entities<< process_entity(data, entity_name)
+  elsif data.is_a? Array
+    # the file contains a list of entities
+    data.each do |entity_data|
+      $already_loaded = {}
+      # clear the set of identifiers, becuause each node should
+      # be processed independently
+      $identifiers.clear
+      entities << process_entity(entity_data, 'Placeholder')
+    end
   end
+
+  write_file(entities)
+
+  Tracker::writeDependenciesFile($options, $options[:output])
+rescue StandardError => e
+  abort "process_hierarchy: #{ENTITY_SRC}: #{e.message}"
 end
-
-write_file(entities)
-
-Tracker::writeDependenciesFile($options, $options[:output])

--- a/Tools/ruby/yml2vpb.rb
+++ b/Tools/ruby/yml2vpb.rb
@@ -8,6 +8,7 @@
 
 require 'optparse'
 
+require 'fileutils'
 require 'set'
 require 'erb'
 require 'yaml'
@@ -43,8 +44,30 @@ optparser = OptionParser.new do |opts|
   end
 end
 
-optparser.parse!
-raise "ERROR: No input file specified!" if ARGV.length != 1
+begin
+  optparser.parse!
+rescue OptionParser::ParseError => e
+  abort "yml2vpb: #{e.message}"
+end
+
+abort "yml2vpb: expected exactly one input file" if ARGV.length != 1
+
+SRC = ARGV[0]
+
+abort "yml2vpb: input file not found: #{SRC}" if !File.file?(SRC)
+
+$options[:defaults].each do |filename|
+  abort "yml2vpb: defaults file not found: #{filename}" if !File.file?(filename)
+end
+
+$options[:require_dirs].each do |dir|
+  abort "yml2vpb: require directory not found: #{dir}" if !File.directory?(dir)
+end
+
+if $options[:output]
+  output_dir = File.dirname($options[:output])
+  FileUtils.mkdir_p(output_dir) if output_dir && output_dir != '.'
+end
 
 $options[:require_dirs].each do |dir|
   $LOAD_PATH << dir
@@ -55,8 +78,6 @@ end
 
 require_relative 'tracker'
 require_relative 'lib/entity_util'
-
-SRC = ARGV[0]
 
 # Useful function I wish hashes had.. should probably go in some utility file somewhere
 class Hash
@@ -163,6 +184,26 @@ def symbolize_keys(hash)
   end
 end
 
+def load_erb_yaml_file(filename, description)
+  content = File.open(filename, "r:UTF-8") { |f| ERB.new(f.read).result }
+  YAML.load(content)
+rescue Psych::Exception => e
+  raise "#{description} has invalid YAML: #{e.message}"
+rescue SystemCallError => e
+  raise "#{description} could not be read: #{e.message}"
+end
+
+def load_erb_yaml_stream(filename)
+  content = File.open(filename, "r:UTF-8") { |f| ERB.new(f.read).result }
+  documents = YAML.load_stream(content)
+  raise "input file '#{filename}' must contain at least one YAML document" if documents.empty?
+  documents
+rescue Psych::Exception => e
+  raise "input file '#{filename}' has invalid YAML: #{e.message}"
+rescue SystemCallError => e
+  raise "input file '#{filename}' could not be read: #{e.message}"
+end
+
 class Constants
   NUL = "\0"
 end
@@ -175,32 +216,32 @@ def process(pb_type, pb_vals)
   protocol.new(fieldsHash)
 end
 
-if $options[:defaults]
-  $defaults = $options[:defaults].inject({}) do |acc, filename|
-    File.open(filename , 'r') do |f|
-      content = ERB.new(f.read).result
-      acc.deep_merge(symbolize_keys( YAML.load(content) ))
+begin
+  if $options[:defaults]
+    $defaults = $options[:defaults].inject({}) do |acc, filename|
+      defaults = load_erb_yaml_file(filename, "defaults file '#{filename}'")
+      raise "defaults file '#{filename}' must be a YAML mapping" if !defaults.is_a?(Hash)
+      acc.deep_merge(symbolize_keys(defaults))
     end
   end
-end
 
-content = File.open(SRC, "r:UTF-8") { |f| ERB.new(f.read).result }
+  output = load_erb_yaml_stream(SRC).map.with_index do |data, i|
+    raise "document #{i + 1} root node should be a hash" if !data.is_a?(Hash)
+    raise "document #{i + 1} should contain a single protocol buffer" if data.length != 1
 
-out_stream = $options[:output] ? File.open($options[:output], "wb:UTF-8") : $stdout
-out_stream.binmode
+    pb_type, pb_vals = data.to_a[0]
+    pb = process(pb_type, pb_vals)
+    pb.serialize_to_string + Constants::NUL
+  end
 
-YAML.load_stream(content).each do |data|
-  raise "Root node should be a hash" if not data.is_a? Hash
-  raise "File should contain a single protocol buffer" if data.length != 1
+  out_stream = $options[:output] ? File.open($options[:output], "wb:UTF-8") : $stdout
+  out_stream.binmode
+  output.each { |out_data| out_stream.print(out_data) }
 
-  pb_type, pb_vals = data.to_a[0]
-  pb = process(pb_type, pb_vals)
-  out_data = pb.serialize_to_string
-
-  out_stream.print (out_data + Constants::NUL)
-end
-
-if $options[:output]
-  out_stream.close
-  Tracker::writeDependenciesFile($options, $options[:output])
+  if $options[:output]
+    out_stream.close
+    Tracker::writeDependenciesFile($options, $options[:output])
+  end
+rescue StandardError => e
+  abort "yml2vpb: #{SRC}: #{e.message}"
 end


### PR DESCRIPTION
This ports targeted validation and error-reporting improvements for the shared
Ruby conversion scripts, while leaving the behavior-tree converters to their own
dedicated PR.

Why this makes sense:

- These scripts are common build/data conversion entry points, so clearer
  failures reduce friction before the higher-risk resource and runtime ports.
- The changes stay on Alex's current script baseline and avoid broad build
  generator changes.
- Nested-output creation and input validation make the scripts friendlier to
  automated smoke harnesses and future external-project workflows.

What changed:

- Added option parse diagnostics, input/default/require-directory checks, and
  clearer YAML/read/write failures to `combine_yaml.rb`, `expand_erb.rb`,
  `maya2pb.rb`, `nameDataHashListGen.rb`, `process_hierarchy.rb`, and
  `yml2vpb.rb`.
- Added output parent directory creation for scripts that write files.
- Moved `maya2pb.rb` depfile writing until after successful output generation.
- Did not modify `yml2vbt.rb` or `xml2vbt.rb`; those are covered by PR 04.

Validation:

- `ruby -c` on all six touched scripts.
- Smoke-checked `combine_yaml.rb` and `expand_erb.rb` with nested output paths.
- Negative-smoke checked missing-input handling for `yml2vpb.rb`,
  `nameDataHashListGen.rb`, and `process_hierarchy.rb`.
- `git diff --check`