### PR TITLE
Make behavior tree conversion portable

### DIFF
--- a/Documents/BehaviorTreeConversion.md
+++ b/Documents/BehaviorTreeConversion.md
@@ -1,0 +1,70 @@
+# Behavior Tree Conversion
+
+`Tools/ruby/yml2vbt.rb` and `Tools/ruby/xml2vbt.rb` always require the engine behavior tree protobuf binding:
+
+```text
+Engine/AI/BehaviorTree/BehaviorCommon.pb.rb
+```
+
+Project-specific behavior bindings are configurable. The converters still try to load the legacy Tank binding when it is present so existing Tank projects keep working, but missing Tank files are no longer fatal for engine-only projects.
+
+## Project Behavior Bindings
+
+Use `--project-behavior-proto` for each project behavior protobuf Ruby binding required by a behavior tree:
+
+```powershell
+ruby Tools/ruby/yml2vbt.rb `
+  -I _build/ruby `
+  --project-behavior-proto Project/AI/ProjectBehaviorCommon.pb.rb `
+  -o out/tree.vbt Data/BehaviorTrees/tree.btyml
+```
+
+The option is repeatable. Pass `--no-default-project-behavior-proto` when a project should not even attempt the optional legacy Tank require.
+
+If a behavior tree references a type that cannot be resolved, the converters report the missing protobuf type and point at `--project-behavior-proto` instead of failing while requiring `Tank/AI/TankBehaviorCommon.pb.rb`.
+
+## XML Type Prefixes
+
+XML behavior tree node names map from an XML prefix to a protobuf enum prefix. Built-in mappings are:
+
+```text
+behavior_      -> BehaviorType_
+decorator_     -> DecoratorType_
+tankbehavior_  -> TankBehaviorType_
+tankdecorator_ -> TankDecoratorType_
+```
+
+Add project action prefixes with `--behavior-prefix`:
+
+```powershell
+ruby Tools/ruby/xml2vbt.rb `
+  -I _build/ruby `
+  --project-behavior-proto Project/AI/ProjectBehaviorCommon.pb.rb `
+  --behavior-prefix projectbehavior_:ProjectBehaviorType_ `
+  -o out/tree.vbt Data/BehaviorTrees/tree.btxml
+```
+
+Add project decorator prefixes with `--decorator-prefix`:
+
+```powershell
+ruby Tools/ruby/xml2vbt.rb `
+  -I _build/ruby `
+  --project-behavior-proto Project/AI/ProjectBehaviorCommon.pb.rb `
+  --decorator-prefix projectdecorator_:ProjectDecoratorType_ `
+  -o out/tree.vbt Data/BehaviorTrees/tree.btxml
+```
+
+## Test Runner
+
+Run the focused smoke test with:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File Tools/Tests/BehaviorTreeConversion/Run.ps1
+```
+
+The runner creates temporary protobuf stubs and verifies:
+
+- engine-only YAML conversion does not require Tank behavior bindings
+- project YAML behavior types fail with a targeted diagnostic until their project proto is configured
+- engine-only XML conversion uses engine behavior prefixes
+- custom XML behavior prefixes resolve when paired with a project behavior proto

--- a/Tools/Tests/BehaviorTreeConversion/Run.ps1
+++ b/Tools/Tests/BehaviorTreeConversion/Run.ps1
@@ -1,0 +1,333 @@
+param()
+
+$ErrorActionPreference = 'Stop'
+
+$RepoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\..\..'))
+$BuildRoot = Join-Path $RepoRoot 'Tools\test-build\BehaviorTreeConversion'
+$StubRoot = Join-Path $BuildRoot 'ruby-stubs'
+$InputRoot = Join-Path $BuildRoot 'input'
+$OutRoot = Join-Path $BuildRoot 'out'
+
+Remove-Item -LiteralPath $BuildRoot -Recurse -Force -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Path $StubRoot, $InputRoot, $OutRoot | Out-Null
+New-Item -ItemType Directory -Path (Join-Path $BuildRoot '_build\proto') | Out-Null
+Set-Content -Encoding ASCII -Path (Join-Path $BuildRoot '_build\proto\deps.txt') -Value ''
+
+$env:USAGI_DIR = $RepoRoot
+
+$EngineStubDir = Join-Path $StubRoot 'Engine\AI\BehaviorTree'
+$ProjectStubDir = Join-Path $StubRoot 'Project\AI'
+New-Item -ItemType Directory -Path $EngineStubDir, $ProjectStubDir | Out-Null
+
+@'
+module Usg
+  module Ai
+    class FakeMessage
+      def initialize(attrs = {})
+        self.attributes = attrs
+      end
+
+      def self.fields
+        {}
+      end
+
+      def fields
+        self.class.fields
+      end
+
+      def attributes=(attrs)
+        attrs.each do |key, value|
+          instance_variable_set("@#{key}", value)
+        end
+      end
+
+      def serialize_to_string
+        self.class.name
+      end
+    end
+
+    module CompositeType
+      CompositeType_Sequence = 1
+      Decorator = 2
+      Behavior = 3
+    end
+
+    module BehaviorType
+      BehaviorType_Wait = 10
+    end
+
+    module DecoratorType
+    end
+
+    class CompositeHeader < FakeMessage
+      attr_accessor :compositeType
+    end
+
+    class SequenceHeader < FakeMessage
+      attr_accessor :numChildren
+    end
+
+    class BehaviorHeader < FakeMessage
+      attr_accessor :behaviorType
+    end
+
+    class DecoratorHeader < FakeMessage
+      attr_accessor :decoratorHeader
+    end
+  end
+end
+'@ | Set-Content -Encoding ASCII -Path (Join-Path $EngineStubDir 'BehaviorCommon.pb.rb')
+
+@'
+module Usg
+  module Ai
+    module ProjectBehaviorType
+      ProjectBehaviorType_Idle = 100
+    end
+  end
+end
+'@ | Set-Content -Encoding ASCII -Path (Join-Path $ProjectStubDir 'ProjectBehaviorCommon.pb.rb')
+
+@'
+require 'rexml/document'
+
+module Nokogiri
+  VERSION = 'behavior-conversion-test-stub'
+
+  def self.XML(io)
+    yield Config.new if block_given?
+    Document.new(REXML::Document.new(io.read))
+  end
+
+  class Config
+    def strict
+    end
+  end
+
+  class Document
+    attr_reader :root
+
+    def initialize(document)
+      @document = document
+      @root = wrap(document.root)
+    end
+
+    def xpath(query)
+      elements = []
+      @document.elements.each('//*') { |element| elements << element }
+
+      result = case query
+      when '//*'
+        elements
+      when %r{\A//\*\[@start='true'\]\z}
+        elements.select { |element| element.attributes['start'] == 'true' }
+      when %r{\A//\*\[@name='([^']+)'\]\z}
+        name = Regexp.last_match(1)
+        elements.select { |element| element.attributes['name'] == name }
+      when %r{\A//xmlns:transition\[@toState='([^']+)'\]\z}
+        to_state = Regexp.last_match(1)
+        elements.select { |element| element.name == 'transition' && element.attributes['toState'] == to_state }
+      when %r{\A//xmlns:transition\[@fromState='([^']+)'\]\z}
+        from_state = Regexp.last_match(1)
+        elements.select { |element| element.name == 'transition' && element.attributes['fromState'] == from_state }
+      else
+        []
+      end
+
+      result.map { |element| wrap(element) }
+    end
+
+    private
+
+    def wrap(element)
+      element && Node.new(element)
+    end
+  end
+
+  class Node
+    attr_reader :name
+
+    def initialize(element)
+      @element = element
+      @name = element.name
+    end
+
+    def [](key)
+      @element.attributes[key]
+    end
+
+    def attributes
+      Hash[@element.attributes.map { |key, value| [key, value] }]
+    end
+
+    def eql?(other)
+      other.is_a?(Node) && other.element.equal?(@element)
+    end
+
+    def hash
+      @element.object_id.hash
+    end
+
+    protected
+
+    attr_reader :element
+  end
+end
+'@ | Set-Content -Encoding ASCII -Path (Join-Path $StubRoot 'nokogiri.rb')
+
+$EngineYml = Join-Path $InputRoot 'engine_only.btyml'
+@'
+- Behavior:
+    type: Composite
+    name: Sequence
+    numChildren: 0
+'@ | Set-Content -Encoding ASCII -Path $EngineYml
+
+$ProjectYml = Join-Path $InputRoot 'project_behavior.btyml'
+@'
+- Behavior:
+    type: Action
+    name: ProjectBehaviorType_Idle
+    hasData: false
+'@ | Set-Content -Encoding ASCII -Path $ProjectYml
+
+$EngineXml = Join-Path $InputRoot 'engine_only.btxml'
+@'
+<stateMachine xmlns="gap">
+  <composite_Sequence name="Root" start="true" numChildren="1" PositionX="0" />
+  <behavior_Wait name="Wait" PositionX="1" />
+  <transition fromState="Root" toState="Wait" />
+</stateMachine>
+'@ | Set-Content -Encoding ASCII -Path $EngineXml
+
+$ProjectXml = Join-Path $InputRoot 'project_behavior.btxml'
+@'
+<stateMachine xmlns="gap">
+  <composite_Sequence name="Root" start="true" numChildren="1" PositionX="0" />
+  <projectbehavior_Idle name="Idle" PositionX="1" />
+  <transition fromState="Root" toState="Idle" />
+</stateMachine>
+'@ | Set-Content -Encoding ASCII -Path $ProjectXml
+
+function Invoke-RubyConverter {
+  param(
+    [string[]] $Arguments,
+    [switch] $ExpectFailure
+  )
+
+  Push-Location $BuildRoot
+  try {
+    $previousErrorActionPreference = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    $output = & ruby @Arguments 2>&1
+    $exitCode = $LASTEXITCODE
+  } finally {
+    $ErrorActionPreference = $previousErrorActionPreference
+    Pop-Location
+  }
+
+  if ($ExpectFailure) {
+    if ($exitCode -eq 0) {
+      throw "Expected converter failure, but command succeeded: ruby $($Arguments -join ' ')"
+    }
+  } elseif ($exitCode -ne 0) {
+    $output | Write-Host
+    throw "Converter failed with exit code ${exitCode}: ruby $($Arguments -join ' ')"
+  }
+
+  return ($output | Out-String)
+}
+
+$YmlConverter = Join-Path $RepoRoot 'Tools\ruby\yml2vbt.rb'
+$XmlConverter = Join-Path $RepoRoot 'Tools\ruby\xml2vbt.rb'
+
+Invoke-RubyConverter -Arguments @(
+  '-I', $StubRoot,
+  $YmlConverter,
+  '--no-default-project-behavior-proto',
+  '-o', (Join-Path $OutRoot 'engine_only.vbt'),
+  $EngineYml
+) | Out-Null
+
+$missingProjectOutput = Invoke-RubyConverter -ExpectFailure -Arguments @(
+  '-I', $StubRoot,
+  $YmlConverter,
+  '--no-default-project-behavior-proto',
+  '-o', (Join-Path $OutRoot 'missing_project.vbt'),
+  $ProjectYml
+)
+
+if ($missingProjectOutput -notmatch 'Could not resolve behavior tree protobuf type' -or
+    $missingProjectOutput -notmatch 'ProjectBehaviorType_Idle') {
+  throw "Missing project behavior diagnostic did not name the unresolved protobuf type: $missingProjectOutput"
+}
+if ($missingProjectOutput -notmatch '--project-behavior-proto') {
+  throw "Missing project behavior diagnostic did not mention --project-behavior-proto: $missingProjectOutput"
+}
+
+Invoke-RubyConverter -Arguments @(
+  '-I', $StubRoot,
+  $YmlConverter,
+  '--no-default-project-behavior-proto',
+  '--project-behavior-proto', 'Project/AI/ProjectBehaviorCommon.pb.rb',
+  '-o', (Join-Path $OutRoot 'project_behavior.vbt'),
+  $ProjectYml
+) | Out-Null
+
+Invoke-RubyConverter -Arguments @(
+  '-I', $StubRoot,
+  $XmlConverter,
+  '--no-default-project-behavior-proto',
+  '-o', (Join-Path $OutRoot 'engine_only_xml.vbt'),
+  $EngineXml
+) | Out-Null
+
+$missingXmlPrefixOutput = Invoke-RubyConverter -ExpectFailure -Arguments @(
+  '-I', $StubRoot,
+  $XmlConverter,
+  '--no-default-project-behavior-proto',
+  '-o', (Join-Path $OutRoot 'missing_project_prefix_xml.vbt'),
+  $ProjectXml
+)
+
+if ($missingXmlPrefixOutput -notmatch '--behavior-prefix') {
+  throw "XML project behavior prefix diagnostic did not mention --behavior-prefix: $missingXmlPrefixOutput"
+}
+
+$missingXmlProjectOutput = Invoke-RubyConverter -ExpectFailure -Arguments @(
+  '-I', $StubRoot,
+  $XmlConverter,
+  '--no-default-project-behavior-proto',
+  '--behavior-prefix', 'projectbehavior_:ProjectBehaviorType_',
+  '-o', (Join-Path $OutRoot 'missing_project_xml.vbt'),
+  $ProjectXml
+)
+
+if ($missingXmlProjectOutput -notmatch 'Could not resolve behavior tree protobuf type' -or
+    $missingXmlProjectOutput -notmatch 'ProjectBehaviorType_Idle') {
+  throw "XML project behavior diagnostic did not name the unresolved protobuf type: $missingXmlProjectOutput"
+}
+
+Invoke-RubyConverter -Arguments @(
+  '-I', $StubRoot,
+  $XmlConverter,
+  '--no-default-project-behavior-proto',
+  '--behavior-prefix', 'projectbehavior_:ProjectBehaviorType_',
+  '--project-behavior-proto', 'Project/AI/ProjectBehaviorCommon.pb.rb',
+  '-o', (Join-Path $OutRoot 'project_behavior_xml.vbt'),
+  $ProjectXml
+) | Out-Null
+
+foreach ($Path in @(
+  'engine_only.vbt',
+  'project_behavior.vbt',
+  'engine_only_xml.vbt',
+  'project_behavior_xml.vbt'
+)) {
+  $FullPath = Join-Path $OutRoot $Path
+  if (-not (Test-Path $FullPath)) {
+    throw "Expected converter output was not produced: $FullPath"
+  }
+}
+
+Write-Host "Behavior tree conversion smoke passed: $OutRoot"

--- a/Tools/ruby/xml2vbt.rb
+++ b/Tools/ruby/xml2vbt.rb
@@ -4,14 +4,7 @@
 #Converts a XML file to a binary behavior tree file
 
 require 'optparse'
-
-require 'nokogiri'
-
-require_relative 'tracker'
-
-require_relative 'lib/entity_util'
-require 'Engine/AI/BehaviorTree/BehaviorCommon.pb.rb'
-require 'Tank/AI/TankBehaviorCommon.pb.rb'
+require 'fileutils'
 
 ### CONVERTER CLASS
 
@@ -19,12 +12,88 @@ class XMLBehaviorTreeConverter
   class Constants
     NUL = "\0"
   end
+
+  DEFAULT_PROJECT_BEHAVIOR_PROTO = 'Tank/AI/TankBehaviorCommon.pb.rb'
+  DEFAULT_BEHAVIOR_TYPE_PREFIXES = {
+    "behavior_" => "BehaviorType_",
+    "tankbehavior_" => "TankBehaviorType_"
+  }
+  DEFAULT_DECORATOR_TYPE_PREFIXES = {
+    "decorator_" => "DecoratorType_",
+    "tankdecorator_" => "TankDecoratorType_"
+  }
+
+  def initialize(options = {})
+    @options = options
+    @behavior_type_prefixes = DEFAULT_BEHAVIOR_TYPE_PREFIXES.merge(options.fetch(:behavior_type_prefixes, {}))
+    @decorator_type_prefixes = DEFAULT_DECORATOR_TYPE_PREFIXES.merge(options.fetch(:decorator_type_prefixes, {}))
+  end
+
   def run(input, output)
-    @@xml = Nokogiri::XML(File.open(input, 'r'))
-    @@pb_file = File.open(output, "wb")
-    @@pb_file.binmode
-    parse_tree(@@xml)
-    @@pb_file.close
+    require 'nokogiri'
+
+    @@xml = File.open(input, 'r') { |file| Nokogiri::XML(file) { |config| config.strict } }
+    validate_tree(@@xml)
+    load_converter_dependencies
+
+    File.open(output, "wb") do |pb_file|
+      @@pb_file = pb_file
+      @@pb_file.binmode
+      parse_tree(@@xml)
+    end
+  ensure
+    @@xml = nil
+    @@pb_file = nil
+  end
+
+  def load_converter_dependencies
+    require_relative 'tracker'
+    require_relative 'lib/entity_util'
+    require 'Engine/AI/BehaviorTree/BehaviorCommon.pb.rb'
+
+    if @options.fetch(:use_default_project_behavior_proto, true)
+      require_project_behavior_proto(DEFAULT_PROJECT_BEHAVIOR_PROTO, true)
+    end
+
+    @options.fetch(:project_behavior_protos, []).each do |proto|
+      require_project_behavior_proto(proto, false)
+    end
+  end
+
+  def require_project_behavior_proto(proto, optional)
+    require proto
+  rescue LoadError => e
+    raise e unless optional && missing_required_feature?(e, proto)
+  end
+
+  def missing_required_feature?(error, feature)
+    (error.respond_to?(:path) && error.path == feature) ||
+      error.message.include?(" -- #{feature}") ||
+      error.message.include?("such file -- #{feature}")
+  end
+
+  def resolve_bt_pb(pb_type, context = nil)
+    pb = find_bt_pb(pb_type)
+    return pb unless pb.nil?
+
+    raise unresolved_pb_message(pb_type, context)
+  rescue NameError
+    raise unresolved_pb_message(pb_type, context)
+  end
+
+  def resolve_bt_pb_enum(pb_type, context = nil)
+    pb = find_bt_pb_enum(pb_type)
+    return pb unless pb.nil?
+
+    raise unresolved_pb_message(pb_type, context)
+  rescue NameError
+    raise unresolved_pb_message(pb_type, context)
+  end
+
+  def unresolved_pb_message(pb_type, context)
+    message = "Could not resolve behavior tree protobuf type '#{pb_type}'"
+    message += " for #{context}" if context
+    message + ". Add --project-behavior-proto for project-specific behavior data."
   end
 
   def parse_tree(xml)
@@ -45,23 +114,30 @@ class XMLBehaviorTreeConverter
     type = get_behavior_type(current)
 
     case type
-    when "composite"
+    when :composite
       # puts "composite"
       add_composite(current)
-    when "decorator"
+    when :decorator
       # puts "decorator"
       add_decorator(current)
-    when "tankdecorator"
-      # puts "decorator"
-      add_decorator(current)
-    when "behavior"
+    when :behavior
       # puts "behavior"
       add_action(current)
-    when "tankbehavior"
-      # puts "behavior"
-      add_action(current)
+    else
+      raise "Unrecognized XML behavior node prefix for #{current.name}. Add --behavior-prefix or --decorator-prefix for project-specific XML behavior nodes."
     end
 
+  end
+
+  def validate_tree(xml)
+    raise "XML document is empty" if xml.root.nil?
+
+    start_nodes = xml.xpath("//*[@start='true']")
+    raise "XML behavior tree must contain one start='true' node" if start_nodes.empty?
+    raise "XML behavior tree contains multiple start='true' nodes" if start_nodes.length > 1
+
+    behavior_nodes = xml.xpath("//*").select { |node| get_behavior_type(node) != nil }
+    raise "XML behavior tree contains no recognized behavior nodes. Add --behavior-prefix or --decorator-prefix for project-specific XML behavior nodes." if behavior_nodes.empty?
   end
 
   def add_composite(current)
@@ -71,11 +147,11 @@ class XMLBehaviorTreeConverter
 
     # set composite type
     composite_header = Usg::Ai::CompositeHeader.new
-    composite_type = find_bt_pb("CompositeType_" + behaviorName)
+    composite_type = resolve_bt_pb("CompositeType_" + behaviorName, "composite #{behaviorName}")
     composite_header.compositeType = composite_type
 
     # set numChildren
-    composite = find_bt_pb(behaviorName + "Header").new({
+    composite = resolve_bt_pb(behaviorName + "Header", "composite #{behaviorName}").new({
       :numChildren => get_num_children(current)
     })
 
@@ -98,7 +174,7 @@ class XMLBehaviorTreeConverter
 
     # find out what type of decorator this is
     className = get_behavior_name(current)
-    dec_type = find_bt_pb(className)
+    dec_type = resolve_bt_pb(className, "decorator #{className}")
     dec_header = Usg::Ai::DecoratorHeader.new
     dec_header.decoratorHeader = dec_type
     @@pb_file.print(dec_header.serialize_to_string + Constants::NUL)
@@ -117,7 +193,7 @@ class XMLBehaviorTreeConverter
 
     # find out what type of action this is
     className = get_behavior_name(current)
-    bh_type = find_bt_pb(className)
+    bh_type = resolve_bt_pb(className, "action #{className}")
     bh_header = Usg::Ai::BehaviorHeader.new
     bh_header.behaviorType = bh_type
     @@pb_file.print(bh_header.serialize_to_string + Constants::NUL)
@@ -146,9 +222,9 @@ class XMLBehaviorTreeConverter
     hasData = false
     if (attributes.length > 0)
       name = get_behavior_name(current)
-      sub = name.split("_")
+      data_type = get_behavior_data_type_name(current)
       # puts (name)
-      bh = find_bt_pb(sub[1]).new
+      bh = resolve_bt_pb(data_type, "data for #{name}").new
       fields = bh.fields.collect { |k, v| v }.sort! {
         | x, y | x.tag <=> y.tag
       }
@@ -167,8 +243,7 @@ class XMLBehaviorTreeConverter
             fieldClass = field.class.to_s
             case fieldClass
             when "ProtocolBuffers::Field::EnumField"
-              btType = find_bt_pb_enum(sub[1])
-              raise "Can not find protobuf " + sub[1] if btType == nil
+              btType = resolve_bt_pb_enum(data_type, "enum data for #{name}")
               integerValue = btType.fields.find{|key,val| val.name.to_s == field.name.to_s }[1].value_to_name.find{|integerKey, stringName| stringName == value.to_s}[0]
               bh.attributes = { field.name.to_sym => integerValue }
             when "ProtocolBuffers::Field::BoolField"
@@ -205,14 +280,7 @@ class XMLBehaviorTreeConverter
     if behaviorName.start_with?("composite_")
       behaviorName = current.name.sub("composite_", "")
     else
-      nameHash = {
-        "behavior_" => "BehaviorType_",
-        "decorator_" => "DecoratorType_",
-        "tankbehavior_" => "TankBehaviorType_",
-        "tankdecorator_" => "TankDecoratorType_"
-      }
-
-      nameHash.each do |key, value|
+      type_prefixes.each do |key, value|
         if behaviorName.start_with?(key)
           behaviorName = behaviorName.sub(key, value)
         end
@@ -220,6 +288,18 @@ class XMLBehaviorTreeConverter
     end
 
     return behaviorName
+  end
+
+  def get_behavior_data_type_name(current)
+    type_prefixes.each_key do |prefix|
+      return current.name.sub(prefix, "") if current.name.start_with?(prefix)
+    end
+
+    nil
+  end
+
+  def type_prefixes
+    @behavior_type_prefixes.merge(@decorator_type_prefixes)
   end
 
   def get(current)
@@ -234,8 +314,11 @@ class XMLBehaviorTreeConverter
   end
 
   def get_behavior_type(current)
-    type = current.name.split('_')[0]
-    return type
+    return :composite if current.name.start_with?("composite_")
+    return :behavior if @behavior_type_prefixes.keys.any? { |prefix| current.name.start_with?(prefix) }
+    return :decorator if @decorator_type_prefixes.keys.any? { |prefix| current.name.start_with?(prefix) }
+
+    nil
   end
 
   def next_node(xml, current, last = nil)
@@ -286,6 +369,7 @@ class XMLBehaviorTreeConverter
       |child|
       name = child["toState"]
       childNode = xml.xpath("//*[@name='" + name + "']")
+      raise "Transition references missing node: #{name}" if childNode.empty?
       childNodes.push(childNode.first)
     }
 
@@ -315,12 +399,49 @@ class XMLBehaviorTreeConverter
 end
 
 ### THE ACTUAL SCRIPT
-$options = {}
+$options = {
+  load_paths: [],
+  project_behavior_protos: [],
+  use_default_project_behavior_proto: true,
+  behavior_type_prefixes: {},
+  decorator_type_prefixes: {}
+}
+
+def add_type_prefix(mapping, value)
+  xml_prefix, type_prefix = value.split(':', 2)
+  raise OptionParser::InvalidArgument, value if xml_prefix.nil? || xml_prefix.empty? || type_prefix.nil? || type_prefix.empty?
+
+  mapping[xml_prefix] = type_prefix
+end
 
 optparser = OptionParser.new do |opts|
   opts.banner = "Usage: #{$0} [options] infile"
+  opts.on( '-I dir', 'Add a Ruby load path before requiring protobuf bindings' ) do |dir|
+    $options[:load_paths] << dir
+  end
+
   opts.on( '-o file', 'Specifies the filename to output' ) do |f|
     $options[:output] = f
+  end
+
+  opts.on( '--project-behavior-proto require', 'Require a project behavior protobuf Ruby binding' ) do |feature|
+    $options[:project_behavior_protos] << feature
+  end
+
+  opts.on( '--behavior-prefix xml:type', 'Map an XML action prefix to a protobuf enum prefix' ) do |value|
+    add_type_prefix($options[:behavior_type_prefixes], value)
+  end
+
+  opts.on( '--decorator-prefix xml:type', 'Map an XML decorator prefix to a protobuf enum prefix' ) do |value|
+    add_type_prefix($options[:decorator_type_prefixes], value)
+  end
+
+  opts.on( '--no-default-project-behavior-proto', 'Do not optionally require the legacy Tank behavior binding' ) do
+    $options[:use_default_project_behavior_proto] = false
+  end
+
+  opts.on('--MF file', 'Write dependencies file for Ninja') do |f|
+    $options[:depfile] = f
   end
 
   opts.on( '-h', '--help', 'Display this screen' ) do
@@ -329,13 +450,37 @@ optparser = OptionParser.new do |opts|
   end
 end
 
-Tracker::addDepfileOption($options, optparser)
+def create_output_parent_dir(output)
+  parent = File.dirname(output)
+  return if parent.nil? || parent == "."
 
-optparser.parse!
-raise "ERROR: No input file specified!" if ARGV.length != 1
+  raise "Output parent exists and is not a directory: #{parent}" if File.exist?(parent) && !File.directory?(parent)
 
-Tracker::writeDependenciesFile($options, $options[:output]) if $options.has_key?(:output)
+  FileUtils.mkdir_p(parent)
+end
 
-SRC = ARGV[0]
+def configure_load_paths(load_paths)
+  load_paths.each do |dir|
+    raise "Load path does not exist: #{dir}" unless File.directory?(dir)
+    $LOAD_PATH.unshift(dir) unless $LOAD_PATH.include?(dir)
+  end
+end
 
-XMLBehaviorTreeConverter.new().run(SRC, $options[:output])
+begin
+  optparser.parse!
+  raise "No input file specified" if ARGV.length == 0
+  raise "Expected exactly one input file, got #{ARGV.length}" if ARGV.length != 1
+  raise "No output file specified" if !$options[:output] || $options[:output].empty?
+
+  SRC = ARGV[0]
+  raise "Input file does not exist: #{SRC}" unless File.file?(SRC)
+
+  configure_load_paths($options[:load_paths])
+  create_output_parent_dir($options[:output])
+
+  XMLBehaviorTreeConverter.new($options).run(SRC, $options[:output])
+  Tracker::writeDependenciesFile($options, $options[:output])
+rescue OptionParser::ParseError, LoadError, StandardError => e
+  warn "#{File.basename($0)}: ERROR: #{e.message}"
+  exit 1
+end

--- a/Tools/ruby/yml2vbt.rb
+++ b/Tools/ruby/yml2vbt.rb
@@ -5,12 +5,7 @@
 
 require 'yaml'
 require 'optparse'
-
-require_relative 'tracker'
-
-require_relative 'lib/entity_util'
-require 'Engine/AI/BehaviorTree/BehaviorCommon.pb.rb'
-require 'Tank/AI/TankBehaviorCommon.pb.rb'
+require 'fileutils'
 
 ### CONVERTER CLASS
 
@@ -19,13 +14,25 @@ class BehaviorTreeConverter
     NUL = "\0"
   end
 
+  VALID_BEHAVIOR_TYPES = ["Composite", "Decorator", "Action"]
+  DEFAULT_PROJECT_BEHAVIOR_PROTO = 'Tank/AI/TankBehaviorCommon.pb.rb'
+
+  def initialize(options = {})
+    @options = options
+  end
+
   def run(input, output)
-    content = File.open(input, 'r')
-    yaml = YAML.load(content)
-    @@pb_file = File.open(output, 'wb')
-    @@pb_file.binmode
-    parse_tree(yaml)
-    @@pb_file.close
+    yaml = File.open(input, 'r') { |content| YAML.load(content) }
+    validate_tree(yaml)
+    load_converter_dependencies
+
+    File.open(output, 'wb') do |pb_file|
+      @@pb_file = pb_file
+      @@pb_file.binmode
+      parse_tree(yaml)
+    end
+  ensure
+    @@pb_file = nil
   end
 
   def parse_tree(behaviorTree)
@@ -70,13 +77,16 @@ class BehaviorTreeConverter
 
   def parse_behavior_data(name)
     behaviorData = get_behavior_data
-    sub = name.split("_")
-    bh = find_bt_pb(sub[1]).new
+    sub = name.split("_", 2)
+    data_type = sub[1]
+    raise "Can not infer behavior data protobuf type from #{name}" if data_type.nil? || data_type.empty?
+
+    bh = resolve_bt_pb(data_type, "data for #{name}").new
     behaviorData.each {
       |key,value|
       # some of the data we have are protobuf classes
       if value.is_a? String
-        data = find_bt_pb(value) if value.is_a?String
+        data = resolve_bt_pb(value, "data field #{key}")
         bh.attributes = { key.to_sym => data }
       else
         bh.attributes = { key.to_sym => value }
@@ -90,12 +100,77 @@ class BehaviorTreeConverter
     @@current_bh["data"]
   end
 
+  def validate_tree(behaviorTree)
+    raise "YAML root must be a sequence of behavior entries" unless behaviorTree.is_a?(Array)
+
+    behaviorTree.each_with_index do |behavior, index|
+      raise "Behavior entry #{index} must be a map" unless behavior.is_a?(Hash)
+
+      current = behavior["Behavior"]
+      raise "Behavior entry #{index} must contain a Behavior map" unless current.is_a?(Hash)
+
+      type = current["type"]
+      raise "Behavior entry #{index} has invalid type #{type.inspect}" unless VALID_BEHAVIOR_TYPES.include?(type)
+      raise "Behavior entry #{index} is missing name" if current["name"].nil? || current["name"].to_s.empty?
+
+      if type == "Composite"
+        raise "Composite behavior #{current["name"]} is missing numChildren" if current["numChildren"].nil?
+        raise "Parallel behavior #{current["name"]} is missing numSuccess" if current["name"] == "Parallel" && current["numSuccess"].nil?
+      end
+
+      if current["hasData"] == true && !current["data"].is_a?(Hash)
+        raise "Behavior #{current["name"]} declares hasData but data is not a map"
+      end
+    end
+  end
+
+  def load_converter_dependencies
+    require_relative 'tracker'
+    require_relative 'lib/entity_util'
+    require 'Engine/AI/BehaviorTree/BehaviorCommon.pb.rb'
+
+    if @options.fetch(:use_default_project_behavior_proto, true)
+      require_project_behavior_proto(DEFAULT_PROJECT_BEHAVIOR_PROTO, true)
+    end
+
+    @options.fetch(:project_behavior_protos, []).each do |proto|
+      require_project_behavior_proto(proto, false)
+    end
+  end
+
+  def require_project_behavior_proto(proto, optional)
+    require proto
+  rescue LoadError => e
+    raise e unless optional && missing_required_feature?(e, proto)
+  end
+
+  def missing_required_feature?(error, feature)
+    (error.respond_to?(:path) && error.path == feature) ||
+      error.message.include?(" -- #{feature}") ||
+      error.message.include?("such file -- #{feature}")
+  end
+
+  def resolve_bt_pb(pb_type, context = nil)
+    pb = find_bt_pb(pb_type)
+    return pb unless pb.nil?
+
+    raise unresolved_pb_message(pb_type, context)
+  rescue NameError
+    raise unresolved_pb_message(pb_type, context)
+  end
+
+  def unresolved_pb_message(pb_type, context)
+    message = "Could not resolve behavior tree protobuf type '#{pb_type}'"
+    message += " for #{context}" if context
+    message + ". Add --project-behavior-proto for project-specific behavior data."
+  end
+
   def add_composite
     className = get_behavior_name
     composite_header = Usg::Ai::CompositeHeader.new
-    composite_type = find_bt_pb("CompositeType_" + className)
+    composite_type = resolve_bt_pb("CompositeType_" + className, "composite #{className}")
     composite_header.compositeType = composite_type
-    composite = find_bt_pb(className + "Header").new({:numChildren => get_num_children})
+    composite = resolve_bt_pb(className + "Header", "composite #{className}").new({:numChildren => get_num_children})
     if className == "Parallel"
       composite.numSuccess = get_num_success
     end
@@ -111,7 +186,7 @@ class BehaviorTreeConverter
 
     #then we need to find out what type of decorator this is
     className = get_behavior_name
-    dec_type = find_bt_pb(className)
+    dec_type = resolve_bt_pb(className, "decorator #{className}")
     dec_header = Usg::Ai::DecoratorHeader.new
     dec_header.decoratorHeader = dec_type
     @@pb_file.print(dec_header.serialize_to_string + Constants::NUL)
@@ -130,7 +205,7 @@ class BehaviorTreeConverter
 
     #then we need to find out what type of action this is
     className = get_behavior_name
-    bh_type = find_bt_pb(className)
+    bh_type = resolve_bt_pb(className, "action #{className}")
     bh_header = Usg::Ai::BehaviorHeader.new
     bh_header.behaviorType = bh_type
     @@pb_file.print(bh_header.serialize_to_string + Constants::NUL)
@@ -154,12 +229,32 @@ class BehaviorTreeConverter
 end
 
 ### THE ACTUAL SCRIPT
-$options = {}
+$options = {
+  load_paths: [],
+  project_behavior_protos: [],
+  use_default_project_behavior_proto: true
+}
 
 optparser = OptionParser.new do |opts|
   opts.banner = "Usage: #{$0} [options] infile"
+  opts.on( '-I dir', 'Add a Ruby load path before requiring protobuf bindings' ) do |dir|
+    $options[:load_paths] << dir
+  end
+
   opts.on( '-o file', 'Specifies the filename to output' ) do |f|
     $options[:output] = f
+  end
+
+  opts.on( '--project-behavior-proto require', 'Require a project behavior protobuf Ruby binding' ) do |feature|
+    $options[:project_behavior_protos] << feature
+  end
+
+  opts.on( '--no-default-project-behavior-proto', 'Do not optionally require the legacy Tank behavior binding' ) do
+    $options[:use_default_project_behavior_proto] = false
+  end
+
+  opts.on('--MF file', 'Write dependencies file for Ninja') do |f|
+    $options[:depfile] = f
   end
 
   opts.on( '-h', '--help', 'Display this screen' ) do
@@ -168,14 +263,38 @@ optparser = OptionParser.new do |opts|
   end
 end
 
-Tracker::addDepfileOption($options, optparser)
+def create_output_parent_dir(output)
+  parent = File.dirname(output)
+  return if parent.nil? || parent == "."
 
-optparser.parse!
-raise "ERROR: No input file specified!" if ARGV.length != 1
+  raise "Output parent exists and is not a directory: #{parent}" if File.exist?(parent) && !File.directory?(parent)
 
-Tracker::writeDependenciesFile($options, $options[:output]) if $options.has_key?(:output)
+  FileUtils.mkdir_p(parent)
+end
 
-SRC = ARGV[0]
+def configure_load_paths(load_paths)
+  load_paths.each do |dir|
+    raise "Load path does not exist: #{dir}" unless File.directory?(dir)
+    $LOAD_PATH.unshift(dir) unless $LOAD_PATH.include?(dir)
+  end
+end
 
-BehaviorTreeConverter.new().run(SRC, $options[:output])
+begin
+  optparser.parse!
+  raise "No input file specified" if ARGV.length == 0
+  raise "Expected exactly one input file, got #{ARGV.length}" if ARGV.length != 1
+  raise "No output file specified" if !$options[:output] || $options[:output].empty?
+
+  SRC = ARGV[0]
+  raise "Input file does not exist: #{SRC}" unless File.file?(SRC)
+
+  configure_load_paths($options[:load_paths])
+  create_output_parent_dir($options[:output])
+
+  BehaviorTreeConverter.new($options).run(SRC, $options[:output])
+  Tracker::writeDependenciesFile($options, $options[:output])
+rescue OptionParser::ParseError, LoadError, StandardError => e
+  warn "#{File.basename($0)}: ERROR: #{e.message}"
+  exit 1
+end
 #BehaviorTreeConverter.new().run("C:\\Users\\Olof\\Desktop\\behaviorTree.yml", "C:\\Users\\Olof\\Desktop\\behaviorTree.pb")


### PR DESCRIPTION
This updates the YAML and XML behavior-tree converters so they can be used by
engine-only and external projects without requiring the legacy Tank behavior
protobuf binding.

Why this makes sense:

- Future behavior-tree tooling needs conversion knowledge without inheriting a
  Tank-specific project dependency.
- Alex's branch still has the current converter entry points, so this is a
  focused tool compatibility improvement rather than an engine runtime change.
- Targeted diagnostics make missing project behavior bindings actionable instead
  of failing during a hard-coded `require`.

What changed:

- Added `--project-behavior-proto` for repeatable project behavior protobuf
  Ruby bindings.
- Added `--no-default-project-behavior-proto` so engine-only conversion can skip
  the optional Tank binding.
- Added XML `--behavior-prefix` and `--decorator-prefix` mappings for project
  node prefixes.
- Added converter validation, output directory creation, and clearer unresolved
  protobuf-type errors.
- Added `Documents/BehaviorTreeConversion.md` and a focused PowerShell smoke
  test with temporary Ruby protobuf stubs.

Validation:

- `ruby -c Tools/ruby/yml2vbt.rb`
- `ruby -c Tools/ruby/xml2vbt.rb`
- `powershell -ExecutionPolicy Bypass -File Tools/Tests/BehaviorTreeConversion/Run.ps1`
- `git diff --check`