### PR TITLE
Validate pak dependencies before export

### DIFF
--- a/Engine/Resource/FileDependencies.cpp
+++ b/Engine/Resource/FileDependencies.cpp
@@ -21,7 +21,7 @@ namespace usg
 
 	}
 
-	void FileDependencies::Init(class PakFile* pCurrentFile, const PakFileDecl::Dependency* pDependencies, uint32 uDependencyCount)
+	void FileDependencies::Init(class PakFile* pCurrentFile, const char* szPakName, const PakFileDecl::FileInfo* pOwnerFile, const PakFileDecl::Dependency* pDependencies, uint32 uDependencyCount)
 	{
 		m_dependencies.resize(uDependencyCount);
 		for (uint32 i = 0; i < uDependencyCount; i++)
@@ -30,12 +30,32 @@ namespace usg
 			if (pDependencies[i].PakIndex != USG_INVALID_ID)
 			{
 				dep.resHandle = pCurrentFile->GetResource(pDependencies[i].FileCRC);
-				ASSERT(dep.resHandle);
+				if (!dep.resHandle)
+				{
+					DEBUG_PRINT("Missing pak dependency: pak=%s owner=%s owner_crc=0x%08x owner_type=%u dependency=%u file_crc=0x%08x file_crc_no_ext=0x%08x pak_index=%u usage_crc=0x%08x\n",
+						szPakName ? szPakName : "<unknown>",
+						pOwnerFile ? pOwnerFile->szName : "<unknown>",
+						pOwnerFile ? pOwnerFile->CRC : 0,
+						pOwnerFile ? pOwnerFile->uResourceType : 0,
+						i,
+						pDependencies[i].FileCRC,
+						pDependencies[i].FileCRCNoExt,
+						pDependencies[i].PakIndex,
+						pDependencies[i].UsageCRC);
+				}
 			}
 			else
 			{
 				// TODO: Dependencies from other files
-				ASSERT(false);
+				DEBUG_PRINT("Unsupported external pak dependency: pak=%s owner=%s owner_crc=0x%08x owner_type=%u dependency=%u file_crc=0x%08x file_crc_no_ext=0x%08x usage_crc=0x%08x\n",
+					szPakName ? szPakName : "<unknown>",
+					pOwnerFile ? pOwnerFile->szName : "<unknown>",
+					pOwnerFile ? pOwnerFile->CRC : 0,
+					pOwnerFile ? pOwnerFile->uResourceType : 0,
+					i,
+					pDependencies[i].FileCRC,
+					pDependencies[i].FileCRCNoExt,
+					pDependencies[i].UsageCRC);
 			}
 			dep.uFileCRC = pDependencies[i].FileCRC;
 			dep.uUsageCRC = pDependencies[i].UsageCRC;
@@ -57,6 +77,11 @@ namespace usg
 	
 	BaseResHandle FileDependencies::GetDependencyByIndex(uint32 uFileIndex) const
 	{
+		if (uFileIndex >= m_dependencies.size())
+		{
+			DEBUG_PRINT("Dependency index %u out of range. Dependency count is %u\n", uFileIndex, (uint32)m_dependencies.size());
+			return BaseResHandle(nullptr);
+		}
 		return m_dependencies[uFileIndex].resHandle;
 	}
 
@@ -87,7 +112,7 @@ namespace usg
 	{
 		for (auto& dep : m_dependencies)
 		{
-			if (dep.resHandle->GetResourceType() == eType)
+			if (dep.resHandle && dep.resHandle->GetResourceType() == eType)
 			{
 				return dep.resHandle;
 			}
@@ -99,7 +124,7 @@ namespace usg
 	{
 		for (auto& dep : m_dependencies)
 		{
-			if (dep.resHandle->GetResourceType() == eType && (uFileCRCNoExt == dep.uFileCRCNoExt))
+			if (dep.resHandle && dep.resHandle->GetResourceType() == eType && (uFileCRCNoExt == dep.uFileCRCNoExt))
 			{
 				return dep.resHandle;
 			}
@@ -111,7 +136,7 @@ namespace usg
 	{
 		for (auto& dep : m_dependencies)
 		{
-			if (dep.resHandle->GetResourceType() == eType)
+			if (dep.resHandle && dep.resHandle->GetResourceType() == eType)
 			{
 				depOut.push_back(&dep);
 			}

--- a/Engine/Resource/FileDependencies.h
+++ b/Engine/Resource/FileDependencies.h
@@ -26,7 +26,7 @@ namespace usg
 			uint32			uFileCRCNoExt;
 		};
 
-		void Init(class PakFile* pCurrentFile, const PakFileDecl::Dependency* pDependencies, uint32 uDependencyCount);
+		void Init(class PakFile* pCurrentFile, const char* szPakName, const PakFileDecl::FileInfo* pOwnerFile, const PakFileDecl::Dependency* pDependencies, uint32 uDependencyCount);
 		uint32 GetDependencyCount() const { return (uint32)m_dependencies.size(); }
 		BaseResHandle GetDependencyByCRC(uint32 uFileCRC) const;
 		BaseResHandle GetDependencyByCRCAndType(uint32 uFileCRCNoExt, ResourceType eType) const;

--- a/Engine/Resource/PakFile.cpp
+++ b/Engine/Resource/PakFile.cpp
@@ -120,7 +120,7 @@ namespace usg
 #if PAK_FILE_TIMINGS
 			loadTimer.ClearAndStart();
 #endif
-			LoadFile(pDevice, header.uResDataOffset, pFileInfo, scratch.GetRawData());
+			LoadFile(pDevice, szFileName, header.uResDataOffset, pFileInfo, scratch.GetRawData());
 #if PAK_FILE_TIMINGS
 			loadTimer.Stop();
 			LOG_MSG(DEBUG_MSG_RELEASE, "Processed sub file %s in %f milliseconds\n", pFileInfo->szName, loadTimer.GetTotalMilliSeconds());
@@ -180,7 +180,7 @@ namespace usg
 		return nullptr;
 	}
 
-	void PakFile::LoadFile(GFXDevice* pDevice, uint32 uPersistentOffset, const PakFileDecl::FileInfo* pFileInfo, void* pFileScratch)
+	void PakFile::LoadFile(GFXDevice* pDevice, const char* szPakName, uint32 uPersistentOffset, const PakFileDecl::FileInfo* pFileInfo, void* pFileScratch)
 	{
 		string name = pFileInfo->szName;
 		name.make_lower();
@@ -205,7 +205,7 @@ namespace usg
 		if (pFileInfo->uDependenciesCount > 0)
 		{
 			const PakFileDecl::Dependency* pDependencies = PakFileDecl::GetDependencies(pFileInfo);
-			deps.Init(this, pDependencies, pFileInfo->uDependenciesCount);
+			deps.Init(this, szPakName, pFileInfo, pDependencies, pFileInfo->uDependenciesCount);
 		}
 
 		// FIXME: Make the init function virtual to save this mess
@@ -340,4 +340,3 @@ namespace usg
 
 
 }
-

--- a/Engine/Resource/PakFile.h
+++ b/Engine/Resource/PakFile.h
@@ -32,7 +32,7 @@ namespace usg
 		void ClearHandles() { m_resources.clear(); }
 
 	private:
-		void LoadFile(GFXDevice* pDevice, uint32 uPersistentOffset, const PakFileDecl::FileInfo* pFileInfo, void* pFileScratch);
+		void LoadFile(GFXDevice* pDevice, const char* szPakName, uint32 uPersistentOffset, const PakFileDecl::FileInfo* pFileInfo, void* pFileScratch);
 		static ResourceBase* CreateResource(usg::ResourceType eType);
 		
 		void*							m_pPersistantData;

--- a/Tools/Source/PakFileGen/FileFactory.cpp
+++ b/Tools/Source/PakFileGen/FileFactory.cpp
@@ -916,9 +916,9 @@ void FileFactory::AddDependenciesFromDepFile(const char* szDepFileName, Resource
 	}
 }
 
-void FileFactory::ExportResources(const char* szFileName)
+bool FileFactory::ExportResources(const char* szFileName)
 {
-	ResourcePakExporter::Export(szFileName, m_resources);
+	return ResourcePakExporter::Export(szFileName, m_resources);
 }
 
 void FileFactory::WriteDependencies(const char* szFileName)
@@ -980,6 +980,5 @@ std::string FileFactory::RemoveFileName(const std::string& fileName)
 	std::string out = fileName.substr(0, fileName.find_last_of("\\/"));
 	return out;
 }
-
 
 

--- a/Tools/Source/PakFileGen/FileFactory.h
+++ b/Tools/Source/PakFileGen/FileFactory.h
@@ -21,7 +21,7 @@ public:
 	std::string LoadParticleEffect(const char* szFileName);
 	std::string LoadParticleEmitter(const char* szFileName);
 
-	void ExportResources(const char* szFileName);
+	bool ExportResources(const char* szFileName);
 	void WriteDependencies(const char* szFileName);
 
 	void AddTextureDependecy(const char* szTexName, ResourceEntry* pEntry, YAML::Node details);
@@ -108,4 +108,3 @@ protected:
 	std::vector<ResourceEntry*> m_resources;
 	std::vector<std::string> m_referencedFiles;
 };
-

--- a/Tools/Source/PakFileGen/main.cpp
+++ b/Tools/Source/PakFileGen/main.cpp
@@ -198,11 +198,14 @@ int main(int argc, char *argv[])
 	
 
 	// Write out the file
-	g_pFileFactory->ExportResources(outputFile.c_str());
-	g_pFileFactory->WriteDependencies(dependencyFile.c_str());
+	bool bExportSuccess = g_pFileFactory->ExportResources(outputFile.c_str());
+	if (bExportSuccess)
+	{
+		g_pFileFactory->WriteDependencies(dependencyFile.c_str());
+	}
 
 
 	delete g_pFileFactory;
 
-	return 0;
+	return bExportSuccess ? 0 : -1;
 }

--- a/Tools/Source/ResourceLib/ResourcePakExporter.h
+++ b/Tools/Source/ResourceLib/ResourcePakExporter.h
@@ -3,6 +3,7 @@
 #include "Engine/Core/Utility.h"
 #include "Engine/Resource/PakDecl.h"
 #include <algorithm>
+#include <string>
 #include <vector>
 
 struct DependencyEntry
@@ -57,22 +58,6 @@ struct ResourceEntry
 	uint32 GetNameCRCNoExt() const { return uFileCRCNoExt;  }
 	usg::ResourceType GetResourceType() const { return resourceType; }
 
-	bool operator<(const ResourceEntry &rhs) const
-	{
-		const auto& rhsDeps = rhs.GetDeps();
-		if (dependencies.size() == 0 && rhs.dependencies.size() > 0)
-			return true;
-		for (size_t i = 0; i < rhsDeps.size(); i++)
-		{
-			if (rhsDeps[i].fileNameCRC == uFileCRC)
-			{
-				return true;
-			}
-		}
-		return false;
-	}
-
-
 private:
 	std::vector<DependencyEntry> dependencies;
 	std::string name;
@@ -81,18 +66,133 @@ private:
 	uint32 uFileCRCNoExt;
 };
 
-inline bool ComparePointers(const ResourceEntry * const & a, const ResourceEntry * const & b)
-{
-	return *a < *b;
-}
-
 namespace ResourcePakExporter
 {
+	inline bool ResourceEntryLess(const ResourceEntry* pLhs, const ResourceEntry* pRhs)
+	{
+		const int nameCmp = pLhs->GetName().compare(pRhs->GetName());
+		if (nameCmp != 0)
+		{
+			return nameCmp < 0;
+		}
+
+		return pLhs->GetNameCRC() < pRhs->GetNameCRC();
+	}
+
+	inline int FindResourceIndex(const std::vector<ResourceEntry*>& entries, uint32 uFileCRC)
+	{
+		for (uint32 i = 0; i < entries.size(); i++)
+		{
+			if (entries[i]->GetNameCRC() == uFileCRC)
+			{
+				return (int)i;
+			}
+		}
+
+		return -1;
+	}
+
+	inline bool SortAndValidateDependencies(const char* szFileName, std::vector<ResourceEntry*>& entries)
+	{
+		std::sort(entries.begin(), entries.end(), ResourceEntryLess);
+
+		for (uint32 i = 0; i < entries.size(); i++)
+		{
+			for (uint32 j = i + 1; j < entries.size(); j++)
+			{
+				if (entries[i]->GetNameCRC() == entries[j]->GetNameCRC())
+				{
+					RELEASE_WARNING("Resources %s and %s have duplicate CRCs in pak %s\n", entries[i]->GetName().c_str(), entries[j]->GetName().c_str(), szFileName);
+					return false;
+				}
+			}
+		}
+
+		std::vector<std::vector<uint32>> dependents(entries.size());
+		std::vector<uint32> dependencyCounts(entries.size(), 0);
+
+		for (uint32 i = 0; i < entries.size(); i++)
+		{
+			for (auto& depItr : entries[i]->GetDeps())
+			{
+				const int depId = FindResourceIndex(entries, depItr.fileNameCRC);
+				if (depId < 0)
+				{
+					RELEASE_WARNING("Dependency %s for resource %s was not found in pak %s\n", depItr.fileName.c_str(), entries[i]->GetName().c_str(), szFileName);
+					return false;
+				}
+
+				dependents[depId].push_back(i);
+				dependencyCounts[i]++;
+			}
+		}
+
+		for (auto& dependentList : dependents)
+		{
+			std::sort(dependentList.begin(), dependentList.end(), [&](uint32 lhs, uint32 rhs)
+			{
+				return ResourceEntryLess(entries[lhs], entries[rhs]);
+			});
+		}
+
+		std::vector<uint32> ready;
+		for (uint32 i = 0; i < entries.size(); i++)
+		{
+			if (dependencyCounts[i] == 0)
+			{
+				ready.push_back(i);
+			}
+		}
+
+		std::vector<ResourceEntry*> sortedEntries;
+		sortedEntries.reserve(entries.size());
+
+		while (!ready.empty())
+		{
+			std::sort(ready.begin(), ready.end(), [&](uint32 lhs, uint32 rhs)
+			{
+				return ResourceEntryLess(entries[lhs], entries[rhs]);
+			});
+
+			const uint32 entryId = ready.front();
+			ready.erase(ready.begin());
+
+			sortedEntries.push_back(entries[entryId]);
+
+			for (uint32 dependentId : dependents[entryId])
+			{
+				ASSERT(dependencyCounts[dependentId] > 0);
+				dependencyCounts[dependentId]--;
+				if (dependencyCounts[dependentId] == 0)
+				{
+					ready.push_back(dependentId);
+				}
+			}
+		}
+
+		if (sortedEntries.size() != entries.size())
+		{
+			for (uint32 i = 0; i < entries.size(); i++)
+			{
+				if (dependencyCounts[i] > 0)
+				{
+					RELEASE_WARNING("Resource %s has cyclic dependencies in pak %s\n", entries[i]->GetName().c_str(), szFileName);
+				}
+			}
+			return false;
+		}
+
+		entries.swap(sortedEntries);
+		return true;
+	}
+
 	// Note entries may be re-ordered by this function
 	inline bool Export(const char* szFileName, std::vector<ResourceEntry*>& entries)
 	{
-		// Sort these entries so that dependencies come before other files
-		std::sort(entries.begin(), entries.end(), ComparePointers);
+		if (!SortAndValidateDependencies(szFileName, entries))
+		{
+			return false;
+		}
 
 		uint32 uTmpOffset = sizeof(usg::PakFileDecl::ResourcePakHdr);
 		for (uint32 i = 0; i < entries.size(); i++)
@@ -102,38 +202,35 @@ namespace ResourcePakExporter
 			uTmpOffset += (uint32)(entries[i]->GetDeps().size() * sizeof(usg::PakFileDecl::Dependency));
 		}
 
-		bool bHasKeepData = false;
 		uint32 uKeepOffset = uTmpOffset;
+		bool bHasPersistentData = false;
 		for (uint32 i = 0; i < entries.size(); i++)
 		{
 			if (!entries[i]->KeepDataAfterLoading())
 			{
 				uKeepOffset += entries[i]->GetDataSize();
 			}
-			else
+			else if (entries[i]->GetDataSize() > 0)
 			{
-				bHasKeepData = true;
+				bHasPersistentData = true;
 			}
 		}
 
-		if (!bHasKeepData)
-		{
-			uKeepOffset = USG_INVALID_ID;
-		}
+		const uint32 uPersistentDataOffset = bHasPersistentData ? uKeepOffset : USG_INVALID_ID;
 
 		FILE* pFileOut = nullptr;
 		fopen_s(&pFileOut, szFileName, "wb");
 
 		if (!pFileOut)
 		{
-			DEBUG_PRINT("Unable to open file %s", szFileName);
+			RELEASE_WARNING("Unable to open file %s", szFileName);
 			return false;
 		}
 
 		usg::PakFileDecl::ResourcePakHdr hdr;
 		hdr.uVersionId = usg::PakFileDecl::CURRENT_VERSION;
 		hdr.uFileCount = (uint32)entries.size();
-		hdr.uResDataOffset = uKeepOffset;
+		hdr.uResDataOffset = uPersistentDataOffset;
 		hdr.uTempDataOffset = uTmpOffset;
 
 		fwrite(&hdr, sizeof(hdr), 1, pFileOut);
@@ -189,8 +286,15 @@ namespace ResourcePakExporter
 					{
 						if (entries[depId]->GetNameCRC() == depItr.fileNameCRC)
 						{
-							dep.PakIndex = (uint32)i;
+							dep.PakIndex = (uint32)depId;
+							break;
 						}
+					}
+					if (dep.PakIndex == USG_INVALID_ID || dep.PakIndex >= i)
+					{
+						RELEASE_WARNING("Dependency %s for resource %s is not ordered before the resource in pak %s\n", depItr.fileName.c_str(), entries[i]->GetName().c_str(), szFileName);
+						fclose(pFileOut);
+						return false;
 					}
 					fwrite(&dep, sizeof(dep), 1, pFileOut);
 				}

--- a/Tools/Tests/ResourcePakExporter/ResourcePakExporterTests.cpp
+++ b/Tools/Tests/ResourcePakExporter/ResourcePakExporterTests.cpp
@@ -1,0 +1,323 @@
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+#include <direct.h>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <vector>
+
+typedef uint32_t uint32;
+typedef uint8_t uint8;
+
+#define USG_INVALID_ID 0xffffffff
+#define ASSERT(condition) ((void)0)
+#define RELEASE_WARNING(...) printf(__VA_ARGS__)
+
+namespace usg
+{
+	enum class ResourceType : uint32
+	{
+		CUSTOM_EFFECT = 0
+	};
+}
+
+#include "Engine/Resource/PakDecl.h"
+#include "Tools/Source/ResourceLib/ResourcePakExporter.h"
+
+namespace utl
+{
+	static uint32 CRC32Data(const char* pData, size_t uSize, uint32 acc, bool bStopOnZero)
+	{
+		static const uint32 POLYNOMIAL = 0xedb88320;
+		static uint32 crcTable[256];
+		static bool bCrcTableInitialized = false;
+		if (!bCrcTableInitialized)
+		{
+			for (uint32 i = 0; i < 256; ++i)
+			{
+				uint32 c = i;
+				for (uint32 j = 0; j < 8; ++j)
+				{
+					c = (c & 1) ? POLYNOMIAL ^ (c >> 1) : c >> 1;
+				}
+				crcTable[i] = c;
+			}
+
+			bCrcTableInitialized = true;
+		}
+
+		uint32 crc = ~acc;
+		const char* current = pData;
+		if (bStopOnZero)
+		{
+			for (; *current != '\0'; ++current)
+			{
+				crc = crcTable[(crc ^ *current) & 0xff] ^ (crc >> 8);
+			}
+		}
+		else
+		{
+			for (uint32 i = 0; i < uSize; i++)
+			{
+				crc = crcTable[(crc ^ *current) & 0xff] ^ (crc >> 8);
+				++current;
+			}
+		}
+		return ~crc;
+	}
+
+	uint32 CRC32(const char* szString, uint32 acc)
+	{
+		return CRC32Data(szString, (size_t)(-1), acc, true);
+	}
+
+	uint32 CRC32(const void* pData, uint32 uSize, uint32 acc)
+	{
+		return CRC32Data((const char*)pData, (size_t)uSize, acc, false);
+	}
+}
+
+namespace
+{
+	struct TestResourceEntry : public ResourceEntry
+	{
+		explicit TestResourceEntry(const char* szName, bool bKeepData = false)
+			: bKeepDataAfterLoading(bKeepData)
+		{
+			SetName(szName, usg::ResourceType::CUSTOM_EFFECT);
+			data.push_back((uint8)szName[0]);
+		}
+
+		const void* GetData() override { return data.data(); }
+		uint32 GetDataSize() override { return (uint32)data.size(); }
+		bool KeepDataAfterLoading() override { return bKeepDataAfterLoading; }
+		const void* GetCustomHeader() override { return nullptr; }
+		uint32 GetCustomHeaderSize() override { return 0; }
+
+		std::vector<uint8> data;
+		bool bKeepDataAfterLoading;
+	};
+
+	struct PakRecord
+	{
+		usg::PakFileDecl::FileInfo info;
+		std::vector<usg::PakFileDecl::Dependency> dependencies;
+	};
+
+	bool Expect(bool condition, const char* szMessage)
+	{
+		if (!condition)
+		{
+			printf("FAILED: %s\n", szMessage);
+			return false;
+		}
+		return true;
+	}
+
+	std::string JoinPath(const std::string& lhs, const char* rhs)
+	{
+		if (lhs.empty())
+		{
+			return rhs;
+		}
+
+		const char last = lhs[lhs.size() - 1];
+		if (last == '\\' || last == '/')
+		{
+			return lhs + rhs;
+		}
+
+		return lhs + "\\" + rhs;
+	}
+
+	bool ReadPakRecords(const char* szPath, usg::PakFileDecl::ResourcePakHdr& hdr, std::vector<PakRecord>& records)
+	{
+		FILE* pFile = nullptr;
+		if (fopen_s(&pFile, szPath, "rb") != 0 || pFile == nullptr)
+		{
+			printf("FAILED: unable to open %s\n", szPath);
+			return false;
+		}
+
+		if (fread(&hdr, sizeof(hdr), 1, pFile) != 1)
+		{
+			fclose(pFile);
+			return false;
+		}
+
+		records.clear();
+		for (uint32 i = 0; i < hdr.uFileCount; i++)
+		{
+			PakRecord record;
+			if (fread(&record.info, sizeof(record.info), 1, pFile) != 1)
+			{
+				fclose(pFile);
+				return false;
+			}
+
+			if (record.info.uCustomHeaderSize > 0)
+			{
+				fseek(pFile, record.info.uCustomHeaderSize, SEEK_CUR);
+			}
+
+			record.dependencies.resize(record.info.uDependenciesCount);
+			if (!record.dependencies.empty() && fread(record.dependencies.data(), sizeof(usg::PakFileDecl::Dependency), record.dependencies.size(), pFile) != record.dependencies.size())
+			{
+				fclose(pFile);
+				return false;
+			}
+
+			records.push_back(record);
+		}
+
+		fclose(pFile);
+		return true;
+	}
+
+	std::vector<uint8> ReadBytes(const std::string& path)
+	{
+		std::ifstream in(path.c_str(), std::ios::binary);
+		return std::vector<uint8>((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+	}
+
+	bool ExportChain(const std::string& outputPath, const std::vector<int>& order)
+	{
+		TestResourceEntry texture("a_texture.tex");
+		TestResourceEntry material("m_material.yml");
+		TestResourceEntry model("z_model.mdl");
+
+		material.AddDependency(texture.GetName(), "diffuse");
+		model.AddDependency(material.GetName(), "material");
+
+		std::vector<ResourceEntry*> entries;
+		ResourceEntry* allEntries[] = { &texture, &material, &model };
+		for (int index : order)
+		{
+			entries.push_back(allEntries[index]);
+		}
+
+		return ResourcePakExporter::Export(outputPath.c_str(), entries);
+	}
+
+	bool TestDeterministicDependencyOrder(const std::string& outputDir)
+	{
+		const std::string firstPath = JoinPath(outputDir, "dependency_order_first.pak");
+		const std::string secondPath = JoinPath(outputDir, "dependency_order_second.pak");
+
+		if (!Expect(ExportChain(firstPath, { 2, 0, 1 }), "first export succeeds"))
+		{
+			return false;
+		}
+		if (!Expect(ExportChain(secondPath, { 1, 2, 0 }), "second export succeeds"))
+		{
+			return false;
+		}
+
+		usg::PakFileDecl::ResourcePakHdr hdr;
+		std::vector<PakRecord> records;
+		if (!Expect(ReadPakRecords(firstPath.c_str(), hdr, records), "read exported pak records"))
+		{
+			return false;
+		}
+
+		bool ok = true;
+		ok &= Expect(hdr.uVersionId == usg::PakFileDecl::CURRENT_VERSION, "pak version matches");
+		ok &= Expect(records.size() == 3, "pak contains three files");
+		ok &= Expect(strcmp(records[0].info.szName, "a_texture.tex") == 0, "texture sorted first");
+		ok &= Expect(strcmp(records[1].info.szName, "m_material.yml") == 0, "material sorted second");
+		ok &= Expect(strcmp(records[2].info.szName, "z_model.mdl") == 0, "model sorted third");
+		ok &= Expect(records[0].info.CRCNoExt == utl::CRC32("a_texture"), "texture CRCNoExt serialized");
+		ok &= Expect(records[1].dependencies.size() == 1, "material dependency serialized");
+		ok &= Expect(records[1].dependencies[0].PakIndex == 0, "material dependency points at texture");
+		ok &= Expect(records[1].dependencies[0].FileCRCNoExt == utl::CRC32("a_texture"), "dependency CRCNoExt serialized");
+		ok &= Expect(records[2].dependencies.size() == 1, "model dependency serialized");
+		ok &= Expect(records[2].dependencies[0].PakIndex == 1, "model dependency points at material");
+
+		for (uint32 i = 0; i < records.size(); i++)
+		{
+			for (const auto& dep : records[i].dependencies)
+			{
+				ok &= Expect(dep.PakIndex < i, "dependency pak index precedes dependent");
+			}
+		}
+
+		ok &= Expect(ReadBytes(firstPath) == ReadBytes(secondPath), "exports are byte-identical across input order");
+		return ok;
+	}
+
+	bool TestPersistentDataHeader(const std::string& outputDir)
+	{
+		TestResourceEntry tempOnly("temp_only.bin");
+		TestResourceEntry keepData("keep_data.bin", true);
+		std::vector<ResourceEntry*> entries;
+		entries.push_back(&tempOnly);
+		entries.push_back(&keepData);
+
+		const std::string path = JoinPath(outputDir, "persistent_data.pak");
+		if (!Expect(ResourcePakExporter::Export(path.c_str(), entries), "persistent data export succeeds"))
+		{
+			return false;
+		}
+
+		usg::PakFileDecl::ResourcePakHdr hdr;
+		std::vector<PakRecord> records;
+		if (!Expect(ReadPakRecords(path.c_str(), hdr, records), "read persistent data pak records"))
+		{
+			return false;
+		}
+
+		bool ok = true;
+		ok &= Expect(hdr.uResDataOffset != USG_INVALID_ID, "persistent data offset is present");
+		ok &= Expect(records.size() == 2, "persistent data pak contains two files");
+		ok &= Expect(hdr.uResDataOffset == hdr.uTempDataOffset + tempOnly.GetDataSize(), "persistent data starts after temp data");
+		return ok;
+	}
+
+	bool TestMissingDependencyFails(const std::string& outputDir)
+	{
+		TestResourceEntry model("model_with_missing_dep.mdl");
+		model.AddDependency("missing_material.yml", "material");
+
+		std::vector<ResourceEntry*> entries;
+		entries.push_back(&model);
+
+		const std::string path = JoinPath(outputDir, "missing_dependency.pak");
+		return Expect(!ResourcePakExporter::Export(path.c_str(), entries), "missing dependency export fails");
+	}
+
+	bool TestCyclicDependencyFails(const std::string& outputDir)
+	{
+		TestResourceEntry first("cycle_a.bin");
+		TestResourceEntry second("cycle_b.bin");
+		first.AddDependency(second.GetName(), "next");
+		second.AddDependency(first.GetName(), "prev");
+
+		std::vector<ResourceEntry*> entries;
+		entries.push_back(&first);
+		entries.push_back(&second);
+
+		const std::string path = JoinPath(outputDir, "cyclic_dependency.pak");
+		return Expect(!ResourcePakExporter::Export(path.c_str(), entries), "cyclic dependency export fails");
+	}
+}
+
+int main(int argc, char** argv)
+{
+	const std::string outputDir = argc > 1 ? argv[1] : "_resource_pak_exporter_tests";
+	_mkdir(outputDir.c_str());
+
+	bool ok = true;
+	ok &= TestDeterministicDependencyOrder(outputDir);
+	ok &= TestPersistentDataHeader(outputDir);
+	ok &= TestMissingDependencyFails(outputDir);
+	ok &= TestCyclicDependencyFails(outputDir);
+
+	if (ok)
+	{
+		printf("ResourcePakExporter tests passed\n");
+		return 0;
+	}
+
+	return 1;
+}

--- a/Tools/Tests/ResourcePakExporter/Run.ps1
+++ b/Tools/Tests/ResourcePakExporter/Run.ps1
@@ -1,0 +1,124 @@
+$ErrorActionPreference = 'Stop'
+
+$TestDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$UsagiRoot = (Resolve-Path (Join-Path $TestDir '..\..\..')).Path
+
+$SearchRoot = $UsagiRoot
+$EnvScript = $null
+while ($SearchRoot) {
+    $Candidate = Join-Path $SearchRoot 'tools\usagi-dev-env.ps1'
+    if (Test-Path $Candidate) {
+        $EnvScript = $Candidate
+        break
+    }
+
+    $Parent = Split-Path -Parent $SearchRoot
+    if ($Parent -eq $SearchRoot) {
+        break
+    }
+    $SearchRoot = $Parent
+}
+
+if (-not $EnvScript) {
+    throw 'Unable to find tools\usagi-dev-env.ps1 from the test worktree.'
+}
+
+. $EnvScript
+
+$EnvUsagiRoot = $env:USAGI_DIR
+$env:USAGI_DIR = $UsagiRoot
+$ToolsRoot = Split-Path -Parent $EnvScript
+
+if (-not $env:MSBUILD_DIR) {
+    throw 'MSBUILD_DIR is not set. Install Visual Studio Build Tools or update tools\usagi-dev-env.ps1.'
+}
+
+$BuildDir = Join-Path $ToolsRoot 'test-build\ResourcePakExporter'
+New-Item -ItemType Directory -Force -Path $BuildDir | Out-Null
+
+$Source = Join-Path $TestDir 'ResourcePakExporterTests.cpp'
+$Exe = Join-Path $BuildDir 'ResourcePakExporterTests.exe'
+Remove-Item -LiteralPath $Exe -Force -ErrorAction SilentlyContinue
+
+$VcVarsCandidates = @(
+    'C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat',
+    'C:\Program Files\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat',
+    'C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Auxiliary\Build\vcvars64.bat',
+    'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
+)
+$VcVars = $VcVarsCandidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+if (-not $VcVars) {
+    throw 'Unable to find Visual Studio 2022 vcvars64.bat.'
+}
+
+$Defines = @(
+    '/DPLATFORM_PC',
+    '/D_DEBUG',
+    '/DFINAL_BUILD',
+    '/DVK_USE_PLATFORM_WIN32_KHR',
+    '/D"LUA_USER_H=<Engine/Framework/Script/LuaConf.h>"',
+    '/DPB_FIELD_32BIT',
+    '/DNN_SWITCH_ENABLE_HOST_IO',
+    '/DEASTL_USER_DEFINED_ALLOCATOR',
+    '/DEASTL_CUSTOM_FLOAT_CONSTANTS_REQUIRED=1',
+    '/D_CRT_SECURE_NO_WARNINGS'
+)
+
+function Add-IncludeIfExists {
+    param(
+        [System.Collections.Generic.List[string]]$Includes,
+        [string]$Path
+    )
+
+    if ($Path -and (Test-Path $Path)) {
+        $Includes.Add("/I$Path")
+    }
+}
+
+$IncludeList = [System.Collections.Generic.List[string]]::new()
+$IncludeList.Add("/I$(Join-Path $TestDir 'Stubs')")
+$IncludeList.Add("/I$UsagiRoot")
+Add-IncludeIfExists $IncludeList (Join-Path $UsagiRoot '_includes')
+Add-IncludeIfExists $IncludeList (Join-Path $UsagiRoot '_build\win\debug')
+Add-IncludeIfExists $IncludeList (Join-Path $UsagiRoot 'Engine\ThirdParty\nanopb')
+Add-IncludeIfExists $IncludeList (Join-Path $UsagiRoot 'Engine\ThirdParty\EASTL\include')
+Add-IncludeIfExists $IncludeList (Join-Path $UsagiRoot 'Engine\ThirdParty\EASTL\test\packages\EABase\include\Common')
+Add-IncludeIfExists $IncludeList (Join-Path $UsagiRoot 'Engine\ThirdParty\lua-5.3.2\src')
+Add-IncludeIfExists $IncludeList (Join-Path $UsagiRoot 'Engine\ThirdParty\yaml-cpp\include')
+Add-IncludeIfExists $IncludeList (Join-Path $UsagiRoot 'Engine\ThirdParty\gli')
+Add-IncludeIfExists $IncludeList (Join-Path $UsagiRoot 'Engine\ThirdParty\gli\external')
+
+if ($EnvUsagiRoot -and $EnvUsagiRoot -ne $UsagiRoot) {
+    Add-IncludeIfExists $IncludeList (Join-Path $EnvUsagiRoot '_build\win\debug')
+    Add-IncludeIfExists $IncludeList (Join-Path $EnvUsagiRoot 'Engine\ThirdParty\nanopb')
+    Add-IncludeIfExists $IncludeList (Join-Path $EnvUsagiRoot 'Engine\ThirdParty\EASTL\include')
+    Add-IncludeIfExists $IncludeList (Join-Path $EnvUsagiRoot 'Engine\ThirdParty\EASTL\test\packages\EABase\include\Common')
+    Add-IncludeIfExists $IncludeList (Join-Path $EnvUsagiRoot 'Engine\ThirdParty\lua-5.3.2\src')
+    Add-IncludeIfExists $IncludeList (Join-Path $EnvUsagiRoot 'Engine\ThirdParty\yaml-cpp\include')
+    Add-IncludeIfExists $IncludeList (Join-Path $EnvUsagiRoot 'Engine\ThirdParty\gli')
+    Add-IncludeIfExists $IncludeList (Join-Path $EnvUsagiRoot 'Engine\ThirdParty\gli\external')
+}
+
+$Includes = $IncludeList.ToArray()
+
+if ($env:VK_SDK_PATH) {
+    $Includes += "/I$env:VK_SDK_PATH\Include"
+}
+
+$CommandParts = @(
+    "`"$VcVars`" >nul &&",
+    'cl /nologo /std:c++17 /EHsc /MTd /Zi'
+) + $Defines + $Includes + @(
+    "/Fo$BuildDir\",
+    "/Fe$Exe",
+    $Source
+)
+
+$Command = $CommandParts -join ' '
+
+cmd /c $Command
+if ($LASTEXITCODE -ne 0) {
+    throw "ResourcePakExporter test compile failed with exit code $LASTEXITCODE."
+}
+
+& $Exe $BuildDir

--- a/Tools/Tests/ResourcePakExporter/Stubs/Engine/Core/Utility.h
+++ b/Tools/Tests/ResourcePakExporter/Stubs/Engine/Core/Utility.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace utl
+{
+	uint32 CRC32(const char* szString, uint32 acc = 0);
+	uint32 CRC32(const void* pData, uint32 uSize, uint32 acc = 0);
+}

--- a/Tools/Tests/ResourcePakExporter/Stubs/Engine/Graphics/RenderConsts.h
+++ b/Tools/Tests/ResourcePakExporter/Stubs/Engine/Graphics/RenderConsts.h
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace usg
+{
+	enum class ShaderType : uint32
+	{
+		VS = 0,
+		PS,
+		GS,
+		TC,
+		TE,
+		COUNT
+	};
+}


### PR DESCRIPTION
This adds focused pak dependency validation and diagnostics before moving on to
larger resource lifecycle or async-loading work.

Why this makes sense:

- The resource/pak code is a high-conflict area in this port and
  `v0.3-Development`, so dependency correctness should be locked down before
  broader runtime changes.
- Export-time validation catches missing, duplicate, cyclic, and incorrectly
  ordered dependencies before bad paks reach runtime.
- Runtime diagnostics now identify unresolved internal/external dependencies
  without immediately dereferencing null handles.

What changed:

- Added deterministic dependency sorting and validation in
  `ResourcePakExporter`.
- Fixed serialized dependency `PakIndex` to reference the dependency entry.
- Preserved `CRCNoExt` dependency data in the exported pak.
- Made `PakFileGen` fail when export validation fails and write dependency
  files only after a successful export.
- Added pak/runtime diagnostics that include pak name, owner file, CRCs,
  resource type, dependency index, and usage CRC.
- Added a focused native `ResourcePakExporter` smoke test with stubs.

Validation:

- `powershell -NoProfile -ExecutionPolicy Bypass -File Tools/Tests/ResourcePakExporter/Run.ps1` passed.
- The smoke test covers deterministic sorting, correct dependency `PakIndex`,
  `CRCNoExt`, persistent-data offset, missing dependency failure, and cyclic
  dependency failure.
- `git diff --check`