### PR TITLE
Add managed tool core services

### DIFF
--- a/Tools/Source/UsagiTools/src/Usagi.ToolCore/Assets/AssetInventory.cs
+++ b/Tools/Source/UsagiTools/src/Usagi.ToolCore/Assets/AssetInventory.cs
@@ -1,0 +1,38 @@
+namespace Usagi.ToolCore.Assets;
+
+public sealed record AssetItem(string Name, string FullPath, string RelativePath)
+{
+    public override string ToString() => RelativePath;
+}
+
+public static class AssetInventory
+{
+    private static readonly string[] YamlExtensions = [".yml", ".yaml"];
+
+    public static IReadOnlyList<AssetItem> EnumerateYamlAssets(string rootDirectory)
+    {
+        return EnumerateAssets(rootDirectory, YamlExtensions);
+    }
+
+    public static IReadOnlyList<AssetItem> EnumerateAssets(string rootDirectory, IReadOnlyCollection<string> extensions)
+    {
+        if (!Directory.Exists(rootDirectory))
+        {
+            return Array.Empty<AssetItem>();
+        }
+
+        var normalizedExtensions = extensions
+            .Select(extension => extension.StartsWith(".", StringComparison.Ordinal) ? extension : "." + extension)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        return Directory.EnumerateFiles(rootDirectory, "*", SearchOption.AllDirectories)
+            .Where(path => normalizedExtensions.Contains(Path.GetExtension(path)))
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+            .Select(path =>
+            {
+                var relative = Path.GetRelativePath(rootDirectory, path);
+                return new AssetItem(Path.GetFileNameWithoutExtension(path), path, relative);
+            })
+            .ToArray();
+    }
+}

--- a/Tools/Source/UsagiTools/src/Usagi.ToolCore/Commands/CommandHistory.cs
+++ b/Tools/Source/UsagiTools/src/Usagi.ToolCore/Commands/CommandHistory.cs
@@ -1,0 +1,69 @@
+namespace Usagi.ToolCore.Commands;
+
+public sealed class CommandHistory
+{
+    private readonly Stack<HistoryEntry> _undoStack = new();
+    private readonly Stack<HistoryEntry> _redoStack = new();
+    private long _currentRevision;
+    private long _savedRevision;
+    private long _nextRevision = 1;
+
+    public event Action? Changed;
+
+    public bool CanUndo => _undoStack.Count > 0;
+    public bool CanRedo => _redoStack.Count > 0;
+    public bool IsDirty => _currentRevision != _savedRevision;
+
+    public string? UndoDescription => _undoStack.TryPeek(out var entry) ? entry.Command.Description : null;
+    public string? RedoDescription => _redoStack.TryPeek(out var entry) ? entry.Command.Description : null;
+
+    public void Execute(ICommand command)
+    {
+        var entry = new HistoryEntry(command, _currentRevision, _nextRevision++);
+        command.Execute();
+        _currentRevision = entry.AfterRevision;
+        _undoStack.Push(entry);
+        _redoStack.Clear();
+        Changed?.Invoke();
+    }
+
+    public void Undo()
+    {
+        if (!CanUndo) return;
+
+        var entry = _undoStack.Pop();
+        entry.Command.Undo();
+        _currentRevision = entry.BeforeRevision;
+        _redoStack.Push(entry);
+        Changed?.Invoke();
+    }
+
+    public void Redo()
+    {
+        if (!CanRedo) return;
+
+        var entry = _redoStack.Pop();
+        entry.Command.Execute();
+        _currentRevision = entry.AfterRevision;
+        _undoStack.Push(entry);
+        Changed?.Invoke();
+    }
+
+    public void MarkSaved()
+    {
+        _savedRevision = _currentRevision;
+        Changed?.Invoke();
+    }
+
+    public void Clear()
+    {
+        _undoStack.Clear();
+        _redoStack.Clear();
+        _currentRevision = 0;
+        _savedRevision = 0;
+        _nextRevision = 1;
+        Changed?.Invoke();
+    }
+
+    private sealed record HistoryEntry(ICommand Command, long BeforeRevision, long AfterRevision);
+}

--- a/Tools/Source/UsagiTools/src/Usagi.ToolCore/Commands/ICommand.cs
+++ b/Tools/Source/UsagiTools/src/Usagi.ToolCore/Commands/ICommand.cs
@@ -1,0 +1,8 @@
+namespace Usagi.ToolCore.Commands;
+
+public interface ICommand
+{
+    string Description { get; }
+    void Execute();
+    void Undo();
+}

--- a/Tools/Source/UsagiTools/src/Usagi.ToolCore/Process/ProcessRunner.cs
+++ b/Tools/Source/UsagiTools/src/Usagi.ToolCore/Process/ProcessRunner.cs
@@ -1,0 +1,114 @@
+using System.Diagnostics;
+using System.Text;
+
+namespace Usagi.ToolCore.Process;
+
+public sealed record ProcessResult(
+    int ExitCode,
+    string StandardOutput,
+    string StandardError,
+    string? SourceAsset = null)
+{
+    public bool Success => ExitCode == 0;
+
+    public IEnumerable<string> AllLines =>
+        SplitLines(StandardOutput).Concat(SplitLines(StandardError));
+
+    private static IEnumerable<string> SplitLines(string value) =>
+        value.Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(line => line.TrimEnd('\r'));
+}
+
+public sealed class ProcessRunner
+{
+    public async Task<ProcessResult> RunAsync(
+        string executable,
+        IEnumerable<string> arguments,
+        string? workingDirectory = null,
+        string? sourceAsset = null,
+        CancellationToken cancellationToken = default)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = executable,
+            WorkingDirectory = workingDirectory ?? Environment.CurrentDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        foreach (var arg in arguments)
+        {
+            startInfo.ArgumentList.Add(arg);
+        }
+
+        var stdout = new StringBuilder();
+        var stderr = new StringBuilder();
+
+        using var process = new System.Diagnostics.Process { StartInfo = startInfo };
+
+        process.OutputDataReceived += (_, e) =>
+        {
+            if (e.Data is not null)
+            {
+                stdout.AppendLine(e.Data);
+            }
+        };
+
+        process.ErrorDataReceived += (_, e) =>
+        {
+            if (e.Data is not null)
+            {
+                stderr.AppendLine(e.Data);
+            }
+        };
+
+        process.Start();
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        try
+        {
+            await process.WaitForExitAsync(cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+                await process.WaitForExitAsync(CancellationToken.None);
+            }
+
+            throw;
+        }
+
+        return new ProcessResult(
+            process.ExitCode,
+            stdout.ToString(),
+            stderr.ToString(),
+            sourceAsset);
+    }
+
+    public ProcessResult Run(
+        string executable,
+        IEnumerable<string> arguments,
+        string? workingDirectory = null,
+        string? sourceAsset = null,
+        int timeoutMs = 30000)
+    {
+        using var cancellation = new CancellationTokenSource(timeoutMs);
+
+        try
+        {
+            return RunAsync(executable, arguments, workingDirectory, sourceAsset, cancellation.Token)
+                .GetAwaiter()
+                .GetResult();
+        }
+        catch (OperationCanceledException)
+        {
+            return new ProcessResult(-1, string.Empty, "Process timed out.", sourceAsset);
+        }
+    }
+}

--- a/Tools/Source/UsagiTools/src/Usagi.ToolCore/Process/RubyRunner.cs
+++ b/Tools/Source/UsagiTools/src/Usagi.ToolCore/Process/RubyRunner.cs
@@ -1,0 +1,72 @@
+namespace Usagi.ToolCore.Process;
+
+public sealed class RubyRunner
+{
+    private readonly ProcessRunner _processRunner = new();
+    private readonly string _rubyExecutable;
+
+    public RubyRunner(string? rubyExecutable = null)
+    {
+        _rubyExecutable = rubyExecutable ?? FindRuby();
+    }
+
+    public string RubyExecutable => _rubyExecutable;
+
+    public async Task<ProcessResult> RunScriptAsync(
+        string scriptPath,
+        IEnumerable<string> arguments,
+        string? workingDirectory = null,
+        string? sourceAsset = null,
+        CancellationToken cancellationToken = default)
+    {
+        var args = new List<string> { scriptPath };
+        args.AddRange(arguments);
+
+        return await _processRunner.RunAsync(
+            _rubyExecutable,
+            args,
+            workingDirectory,
+            sourceAsset,
+            cancellationToken);
+    }
+
+    public ProcessResult RunScript(
+        string scriptPath,
+        IEnumerable<string> arguments,
+        string? workingDirectory = null,
+        string? sourceAsset = null,
+        int timeoutMs = 30000)
+    {
+        var args = new List<string> { scriptPath };
+        args.AddRange(arguments);
+
+        return _processRunner.Run(
+            _rubyExecutable,
+            args,
+            workingDirectory,
+            sourceAsset,
+            timeoutMs);
+    }
+
+    private static string FindRuby()
+    {
+        var pathDirs = Environment.GetEnvironmentVariable("PATH")?.Split(Path.PathSeparator) ?? [];
+
+        foreach (var dir in pathDirs)
+        {
+            var rubyPath = Path.Combine(dir, "ruby.exe");
+            if (File.Exists(rubyPath))
+            {
+                return rubyPath;
+            }
+
+            rubyPath = Path.Combine(dir, "ruby");
+            if (File.Exists(rubyPath))
+            {
+                return rubyPath;
+            }
+        }
+
+        return "ruby";
+    }
+}

--- a/Tools/Source/UsagiTools/src/Usagi.ToolCore/Projects/UsagiProject.cs
+++ b/Tools/Source/UsagiTools/src/Usagi.ToolCore/Projects/UsagiProject.cs
@@ -1,0 +1,18 @@
+namespace Usagi.ToolCore.Projects;
+
+public sealed record UsagiProject(string RootPath)
+{
+    public string DataPath => Path.Combine(RootPath, "Data");
+    public string EnginePath => Path.Combine(RootPath, "Engine");
+    public string ToolsPath => Path.Combine(RootPath, "Tools");
+    public string RubyPath => Path.Combine(ToolsPath, "ruby");
+    public string BuildPath => Path.Combine(RootPath, "_build");
+    public string RomfilesWinPath => Path.Combine(RootPath, "_romfiles", "win");
+
+    public string ProcessHierarchyScript => Path.Combine(RubyPath, "process_hierarchy.rb");
+
+    public bool HasValidStructure =>
+        Directory.Exists(EnginePath) &&
+        Directory.Exists(DataPath) &&
+        Directory.Exists(ToolsPath);
+}

--- a/Tools/Source/UsagiTools/src/Usagi.ToolCore/Projects/UsagiProjectLocator.cs
+++ b/Tools/Source/UsagiTools/src/Usagi.ToolCore/Projects/UsagiProjectLocator.cs
@@ -1,0 +1,57 @@
+namespace Usagi.ToolCore.Projects;
+
+public static class UsagiProjectLocator
+{
+    public static UsagiProject? TryLocate(string? startDirectory = null)
+    {
+        var environmentRoot = Environment.GetEnvironmentVariable("USAGI_REPO_DIR");
+        if (!string.IsNullOrWhiteSpace(environmentRoot) && IsUsagiRoot(environmentRoot))
+        {
+            return new UsagiProject(Path.GetFullPath(environmentRoot));
+        }
+
+        var usagiDir = Environment.GetEnvironmentVariable("USAGI_DIR");
+        if (!string.IsNullOrWhiteSpace(usagiDir) && IsUsagiRoot(usagiDir))
+        {
+            return new UsagiProject(Path.GetFullPath(usagiDir));
+        }
+
+        var current = new DirectoryInfo(startDirectory ?? Environment.CurrentDirectory);
+        while (current is not null)
+        {
+            if (IsUsagiRoot(current.FullName))
+            {
+                return new UsagiProject(current.FullName);
+            }
+
+            current = current.Parent;
+        }
+
+        return null;
+    }
+
+    public static UsagiProject Locate(string? startDirectory = null)
+    {
+        return TryLocate(startDirectory)
+            ?? throw new DirectoryNotFoundException(
+                "Could not locate a Usagi checkout. Set USAGI_DIR or USAGI_REPO_DIR, or launch from inside the repo.");
+    }
+
+    public static UsagiProject? FromPath(string path)
+    {
+        if (!Directory.Exists(path))
+        {
+            return null;
+        }
+
+        var fullPath = Path.GetFullPath(path);
+        return IsUsagiRoot(fullPath) ? new UsagiProject(fullPath) : null;
+    }
+
+    private static bool IsUsagiRoot(string path)
+    {
+        return Directory.Exists(Path.Combine(path, "Engine")) &&
+               Directory.Exists(Path.Combine(path, "Data")) &&
+               Directory.Exists(Path.Combine(path, "Tools"));
+    }
+}

--- a/Tools/Source/UsagiTools/src/Usagi.ToolCore/Settings/WorkspaceSettings.cs
+++ b/Tools/Source/UsagiTools/src/Usagi.ToolCore/Settings/WorkspaceSettings.cs
@@ -1,0 +1,66 @@
+using System.Text.Json;
+
+namespace Usagi.ToolCore.Settings;
+
+public sealed class WorkspaceSettings
+{
+    private static readonly string SettingsDirectory =
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "UsagiTools");
+
+    private static readonly string SettingsPath =
+        Path.Combine(SettingsDirectory, "workspace.json");
+
+    public string? LastProjectPath { get; set; }
+    public List<string> RecentProjects { get; set; } = [];
+    public string? RubyExecutable { get; set; }
+
+    public static WorkspaceSettings Load() => LoadFrom(SettingsPath);
+
+    public static WorkspaceSettings LoadFrom(string settingsPath)
+    {
+        if (!File.Exists(settingsPath))
+        {
+            return new WorkspaceSettings();
+        }
+
+        try
+        {
+            var json = File.ReadAllText(settingsPath);
+            var settings = JsonSerializer.Deserialize<WorkspaceSettings>(json) ?? new WorkspaceSettings();
+            settings.RecentProjects ??= [];
+            return settings;
+        }
+        catch
+        {
+            return new WorkspaceSettings();
+        }
+    }
+
+    public void Save() => SaveTo(SettingsPath);
+
+    public void SaveTo(string settingsPath)
+    {
+        var settingsDirectory = Path.GetDirectoryName(settingsPath);
+        if (!string.IsNullOrEmpty(settingsDirectory))
+        {
+            Directory.CreateDirectory(settingsDirectory);
+        }
+
+        var options = new JsonSerializerOptions { WriteIndented = true };
+        var json = JsonSerializer.Serialize(this, options);
+        File.WriteAllText(settingsPath, json);
+    }
+
+    public void AddRecentProject(string projectPath)
+    {
+        RecentProjects.Remove(projectPath);
+        RecentProjects.Insert(0, projectPath);
+
+        if (RecentProjects.Count > 10)
+        {
+            RecentProjects.RemoveRange(10, RecentProjects.Count - 10);
+        }
+
+        LastProjectPath = projectPath;
+    }
+}

--- a/Tools/Source/UsagiTools/tests/Usagi.ToolCore.Tests/AssetInventoryTests.cs
+++ b/Tools/Source/UsagiTools/tests/Usagi.ToolCore.Tests/AssetInventoryTests.cs
@@ -1,0 +1,58 @@
+using Usagi.ToolCore.Assets;
+using Xunit;
+
+namespace Usagi.ToolCore.Tests;
+
+public sealed class AssetInventoryTests
+{
+    [Fact]
+    public void EnumerateYamlAssetsReturnsRelativePathsInStableOrder()
+    {
+        using var temp = new TemporaryDirectory();
+        Directory.CreateDirectory(Path.Combine(temp.Path, "Nested"));
+        File.WriteAllText(Path.Combine(temp.Path, "z.yml"), "");
+        File.WriteAllText(Path.Combine(temp.Path, "Nested", "a.yaml"), "");
+        File.WriteAllText(Path.Combine(temp.Path, "ignored.txt"), "");
+
+        var assets = AssetInventory.EnumerateYamlAssets(temp.Path);
+
+        Assert.Equal(["Nested" + Path.DirectorySeparatorChar + "a.yaml", "z.yml"], assets.Select(asset => asset.RelativePath));
+        Assert.Equal(["a", "z"], assets.Select(asset => asset.Name));
+    }
+
+    [Fact]
+    public void EnumerateAssetsFiltersExtensionsCaseInsensitively()
+    {
+        using var temp = new TemporaryDirectory();
+        File.WriteAllText(Path.Combine(temp.Path, "model.VPB"), "");
+        File.WriteAllText(Path.Combine(temp.Path, "sound.wav"), "");
+
+        var assets = AssetInventory.EnumerateAssets(temp.Path, ["vpb"]);
+
+        Assert.Single(assets);
+        Assert.Equal("model", assets[0].Name);
+    }
+
+    [Fact]
+    public void EnumerateAssetsReturnsEmptyListForMissingDirectory()
+    {
+        var assets = AssetInventory.EnumerateAssets(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")), ["yml"]);
+
+        Assert.Empty(assets);
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        public string Path { get; } = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "usagi_assets_" + Guid.NewGuid().ToString("N"));
+
+        public TemporaryDirectory()
+        {
+            Directory.CreateDirectory(Path);
+        }
+
+        public void Dispose()
+        {
+            Directory.Delete(Path, recursive: true);
+        }
+    }
+}

--- a/Tools/Source/UsagiTools/tests/Usagi.ToolCore.Tests/CommandHistoryTests.cs
+++ b/Tools/Source/UsagiTools/tests/Usagi.ToolCore.Tests/CommandHistoryTests.cs
@@ -1,0 +1,129 @@
+using Usagi.ToolCore.Commands;
+using Xunit;
+
+namespace Usagi.ToolCore.Tests;
+
+public sealed class CommandHistoryTests
+{
+    [Fact]
+    public void ExecuteAddsUndoEntryAndMarksDirty()
+    {
+        var state = new List<string>();
+        var history = new CommandHistory();
+
+        history.Execute(new ListCommand("add item", state, "item"));
+
+        Assert.True(history.IsDirty);
+        Assert.True(history.CanUndo);
+        Assert.False(history.CanRedo);
+        Assert.Equal("add item", history.UndoDescription);
+        Assert.Equal(["item"], state);
+    }
+
+    [Fact]
+    public void UndoAndRedoMoveCommandBetweenStacks()
+    {
+        var state = new List<string>();
+        var history = new CommandHistory();
+
+        history.Execute(new ListCommand("add item", state, "item"));
+        history.Undo();
+
+        Assert.Empty(state);
+        Assert.False(history.CanUndo);
+        Assert.True(history.CanRedo);
+        Assert.Equal("add item", history.RedoDescription);
+
+        history.Redo();
+
+        Assert.Equal(["item"], state);
+        Assert.True(history.CanUndo);
+        Assert.False(history.CanRedo);
+    }
+
+    [Fact]
+    public void ExecuteAfterUndoClearsRedoStack()
+    {
+        var state = new List<string>();
+        var history = new CommandHistory();
+
+        history.Execute(new ListCommand("add first", state, "first"));
+        history.Undo();
+        history.Execute(new ListCommand("add second", state, "second"));
+
+        Assert.False(history.CanRedo);
+        Assert.Equal(["second"], state);
+    }
+
+    [Fact]
+    public void MarkSavedTracksCurrentRevision()
+    {
+        var state = new List<string>();
+        var history = new CommandHistory();
+
+        history.Execute(new ListCommand("add first", state, "first"));
+        history.MarkSaved();
+        history.Execute(new ListCommand("add second", state, "second"));
+
+        Assert.True(history.IsDirty);
+
+        history.Undo();
+
+        Assert.False(history.IsDirty);
+    }
+
+    [Fact]
+    public void BranchingFromSavedHistoryRemainsDirty()
+    {
+        var state = new List<string>();
+        var history = new CommandHistory();
+
+        history.Execute(new ListCommand("add saved", state, "saved"));
+        history.MarkSaved();
+        history.Undo();
+        history.Execute(new ListCommand("add different", state, "different"));
+
+        Assert.True(history.IsDirty);
+        Assert.Equal(["different"], state);
+    }
+
+    [Fact]
+    public void ClearResetsHistoryAndDirtyState()
+    {
+        var state = new List<string>();
+        var history = new CommandHistory();
+
+        history.Execute(new ListCommand("add item", state, "item"));
+        history.Clear();
+
+        Assert.False(history.IsDirty);
+        Assert.False(history.CanUndo);
+        Assert.False(history.CanRedo);
+    }
+
+    [Fact]
+    public void ChangedEventFiresForHistoryOperations()
+    {
+        var state = new List<string>();
+        var history = new CommandHistory();
+        var changeCount = 0;
+        history.Changed += () => changeCount++;
+
+        history.Execute(new ListCommand("add item", state, "item"));
+        history.Undo();
+        history.Redo();
+        history.MarkSaved();
+        history.Clear();
+
+        Assert.Equal(5, changeCount);
+    }
+
+    private sealed class ListCommand(string description, List<string> state, string value) : ICommand
+    {
+        public string Description => description;
+
+        public void Execute() => state.Add(value);
+
+        public void Undo() => Assert.True(state.Remove(value));
+    }
+}

--- a/Tools/Source/UsagiTools/tests/Usagi.ToolCore.Tests/ConverterValidationTests.cs
+++ b/Tools/Source/UsagiTools/tests/Usagi.ToolCore.Tests/ConverterValidationTests.cs
@@ -1,0 +1,43 @@
+using Usagi.ToolCore.Process;
+using Xunit;
+
+namespace Usagi.ToolCore.Tests;
+
+public sealed class ConverterValidationTests
+{
+    [Fact]
+    public void ConverterRunnerPreservesSourceAssetOnFailure()
+    {
+        var runner = CreateShellBackedRubyRunner();
+
+        var result = runner.RunScript(ShellSwitch, ["echo converter-error 1>&2 && " + ShellExit(7)], sourceAsset: "Data/test.yml");
+
+        Assert.Equal(7, result.ExitCode);
+        Assert.False(result.Success);
+        Assert.Equal("Data/test.yml", result.SourceAsset);
+        Assert.Contains("converter-error", result.StandardError, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ConverterRunnerCapturesValidationOutput()
+    {
+        var runner = CreateShellBackedRubyRunner();
+
+        var result = runner.RunScript(ShellSwitch, ["echo converter-ok"]);
+
+        Assert.True(result.Success);
+        Assert.Contains("converter-ok", result.StandardOutput, StringComparison.Ordinal);
+    }
+
+    private static string ShellSwitch => OperatingSystem.IsWindows() ? "/c" : "-c";
+
+    private static RubyRunner CreateShellBackedRubyRunner()
+    {
+        return new RubyRunner(OperatingSystem.IsWindows() ? "cmd.exe" : "/bin/sh");
+    }
+
+    private static string ShellExit(int exitCode)
+    {
+        return OperatingSystem.IsWindows() ? $"exit /b {exitCode}" : $"exit {exitCode}";
+    }
+}

--- a/Tools/Source/UsagiTools/tests/Usagi.ToolCore.Tests/ProcessRunnerTests.cs
+++ b/Tools/Source/UsagiTools/tests/Usagi.ToolCore.Tests/ProcessRunnerTests.cs
@@ -1,0 +1,77 @@
+using Usagi.ToolCore.Process;
+using Xunit;
+
+namespace Usagi.ToolCore.Tests;
+
+public sealed class ProcessRunnerTests
+{
+    private readonly ProcessRunner _runner = new();
+
+    [Fact]
+    public void RunCapturesStandardOutput()
+    {
+        var result = RunShell("echo hello");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.True(result.Success);
+        Assert.Contains("hello", result.StandardOutput, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RunCapturesExitCode()
+    {
+        var result = RunShell(OperatingSystem.IsWindows() ? "exit /b 42" : "exit 42");
+
+        Assert.Equal(42, result.ExitCode);
+        Assert.False(result.Success);
+    }
+
+    [Fact]
+    public void RunCapturesStandardError()
+    {
+        var result = RunShell("echo error 1>&2");
+
+        Assert.Contains("error", result.StandardError, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RunPreservesSourceAsset()
+    {
+        var result = RunShell("echo test", sourceAsset: "test.yml");
+
+        Assert.Equal("test.yml", result.SourceAsset);
+    }
+
+    [Fact]
+    public async Task RunAsyncCapturesOutput()
+    {
+        var (executable, arguments) = ShellCommand("echo async");
+
+        var result = await _runner.RunAsync(executable, arguments);
+
+        Assert.True(result.Success);
+        Assert.Contains("async", result.StandardOutput, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AllLinesAggregatesOutputAndError()
+    {
+        var result = RunShell("echo out && echo err 1>&2");
+
+        Assert.Contains(result.AllLines, line => line.Contains("out", StringComparison.Ordinal));
+        Assert.Contains(result.AllLines, line => line.Contains("err", StringComparison.Ordinal));
+    }
+
+    private ProcessResult RunShell(string command, string? sourceAsset = null)
+    {
+        var (executable, arguments) = ShellCommand(command);
+        return _runner.Run(executable, arguments, sourceAsset: sourceAsset);
+    }
+
+    private static (string Executable, string[] Arguments) ShellCommand(string command)
+    {
+        return OperatingSystem.IsWindows()
+            ? ("cmd.exe", ["/c", command])
+            : ("/bin/sh", ["-c", command]);
+    }
+}

--- a/Tools/Source/UsagiTools/tests/Usagi.ToolCore.Tests/UsagiProjectLocatorTests.cs
+++ b/Tools/Source/UsagiTools/tests/Usagi.ToolCore.Tests/UsagiProjectLocatorTests.cs
@@ -1,0 +1,68 @@
+using Usagi.ToolCore.Projects;
+using Xunit;
+
+namespace Usagi.ToolCore.Tests;
+
+public sealed class UsagiProjectLocatorTests
+{
+    [Fact]
+    public void FromPathReturnsProjectForValidRoot()
+    {
+        using var temp = CreateProjectRoot();
+
+        var project = UsagiProjectLocator.FromPath(temp.Path);
+
+        Assert.NotNull(project);
+        Assert.Equal(Path.Combine(temp.Path, "Data"), project.DataPath);
+        Assert.True(project.HasValidStructure);
+    }
+
+    [Fact]
+    public void FromPathRejectsIncompleteRoot()
+    {
+        using var temp = new TemporaryDirectory("usagi_incomplete_");
+        Directory.CreateDirectory(Path.Combine(temp.Path, "Tools"));
+
+        var project = UsagiProjectLocator.FromPath(temp.Path);
+
+        Assert.Null(project);
+    }
+
+    [Fact]
+    public void TryLocateWalksUpFromChildDirectory()
+    {
+        using var temp = CreateProjectRoot();
+        var child = Path.Combine(temp.Path, "Data", "Levels", "Example");
+        Directory.CreateDirectory(child);
+
+        var project = UsagiProjectLocator.TryLocate(child);
+
+        Assert.NotNull(project);
+        Assert.Equal(temp.Path, project.RootPath);
+    }
+
+    private static TemporaryDirectory CreateProjectRoot()
+    {
+        var temp = new TemporaryDirectory("usagi_project_");
+        Directory.CreateDirectory(Path.Combine(temp.Path, "Data"));
+        Directory.CreateDirectory(Path.Combine(temp.Path, "Engine"));
+        Directory.CreateDirectory(Path.Combine(temp.Path, "Tools"));
+        return temp;
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        public string Path { get; }
+
+        public TemporaryDirectory(string prefix)
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), prefix + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path);
+        }
+
+        public void Dispose()
+        {
+            Directory.Delete(Path, recursive: true);
+        }
+    }
+}

--- a/Tools/Source/UsagiTools/tests/Usagi.ToolCore.Tests/WorkspaceSettingsTests.cs
+++ b/Tools/Source/UsagiTools/tests/Usagi.ToolCore.Tests/WorkspaceSettingsTests.cs
@@ -1,0 +1,72 @@
+using Usagi.ToolCore.Settings;
+using Xunit;
+
+namespace Usagi.ToolCore.Tests;
+
+public sealed class WorkspaceSettingsTests
+{
+    [Fact]
+    public void SaveToAndLoadFromRoundTripSettings()
+    {
+        using var temp = new TemporaryDirectory();
+        var settingsPath = Path.Combine(temp.Path, "workspace.json");
+        var settings = new WorkspaceSettings
+        {
+            LastProjectPath = "fixtures/usagi-project",
+            RecentProjects = ["fixtures/usagi-project"],
+            RubyExecutable = "ruby"
+        };
+
+        settings.SaveTo(settingsPath);
+        var loaded = WorkspaceSettings.LoadFrom(settingsPath);
+
+        Assert.Equal(settings.LastProjectPath, loaded.LastProjectPath);
+        Assert.Equal(settings.RecentProjects, loaded.RecentProjects);
+        Assert.Equal(settings.RubyExecutable, loaded.RubyExecutable);
+    }
+
+    [Fact]
+    public void LoadFromReturnsDefaultSettingsForInvalidJson()
+    {
+        using var temp = new TemporaryDirectory();
+        var settingsPath = Path.Combine(temp.Path, "workspace.json");
+        File.WriteAllText(settingsPath, "{ invalid json");
+
+        var settings = WorkspaceSettings.LoadFrom(settingsPath);
+
+        Assert.Null(settings.LastProjectPath);
+        Assert.Empty(settings.RecentProjects);
+    }
+
+    [Fact]
+    public void AddRecentProjectMovesExistingProjectToFrontAndCapsList()
+    {
+        var settings = new WorkspaceSettings();
+        for (var i = 0; i < 12; i++)
+        {
+            settings.AddRecentProject($"Project{i}");
+        }
+
+        settings.AddRecentProject("Project5");
+
+        Assert.Equal("Project5", settings.LastProjectPath);
+        Assert.Equal("Project5", settings.RecentProjects[0]);
+        Assert.Equal(10, settings.RecentProjects.Count);
+        Assert.Equal(1, settings.RecentProjects.Count(project => project == "Project5"));
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        public string Path { get; } = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "usagi_settings_" + Guid.NewGuid().ToString("N"));
+
+        public TemporaryDirectory()
+        {
+            Directory.CreateDirectory(Path);
+        }
+
+        public void Dispose()
+        {
+            Directory.Delete(Path, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
This adds the shared non-UI managed tool services on top of the PR 06
`UsagiTools` solution scaffold.

Why this makes sense:

- The managed editor work needs process execution, project discovery, command
  history, asset inventory, and workspace settings before entity, particle,
  preview, or UI layers can be reviewed sensibly.
- Stacking on PR 06 avoids duplicating the same .NET solution scaffolding across
  multiple independent branches.
- Keeping this branch UI-free and domain-light makes it a reusable base for the
  later managed-tool PRs.

What changed:

- Added `AssetInventory`, command history interfaces, process/Ruby runners,
  project locator types, and workspace settings persistence.
- Added focused non-domain tests for inventory scanning, command undo/redo,
  converter diagnostics, process execution, project discovery, and settings
  persistence.
- Did not add ToolShell UI, entity editor models, particle editor models,
  preview client files, or new audio functionality.

Validation:

- `dotnet test Tools/Source/UsagiTools/UsagiTools.slnx` passed, 44 tests.
- `git diff --check`