### PR TITLE
Add particle document model

### DIFF
--- a/Tools/Source/UsagiTools/src/Usagi.ToolCore/Particles/AnimatedValue.cs
+++ b/Tools/Source/UsagiTools/src/Usagi.ToolCore/Particles/AnimatedValue.cs
@@ -1,0 +1,58 @@
+// Usagi.ToolCore - Particle Editor Support
+// Animated values with keyframes
+
+namespace Usagi.ToolCore.Particles;
+
+/// <summary>
+/// A single keyframe in an animation curve.
+/// </summary>
+public sealed class Keyframe
+{
+    public float TimeIndex { get; set; }
+    public float Value { get; set; }
+
+    public Keyframe() { }
+
+    public Keyframe(float time, float value)
+    {
+        TimeIndex = time;
+        Value = value;
+    }
+}
+
+/// <summary>
+/// An animated float value with keyframes.
+/// </summary>
+public sealed class AnimatedFloat
+{
+    public List<Keyframe> Frames { get; } = [];
+
+    public AnimatedFloat() { }
+
+    public AnimatedFloat(float constantValue)
+    {
+        Frames.Add(new Keyframe(0, constantValue));
+    }
+
+    /// <summary>
+    /// Gets the value at a normalized time (0-1).
+    /// </summary>
+    public float GetValue(float normalizedTime)
+    {
+        if (Frames.Count == 0) return 0;
+        if (Frames.Count == 1) return Frames[0].Value;
+
+        // Find surrounding keyframes and lerp
+        for (int i = 0; i < Frames.Count - 1; i++)
+        {
+            if (normalizedTime >= Frames[i].TimeIndex && normalizedTime <= Frames[i + 1].TimeIndex)
+            {
+                float t = (normalizedTime - Frames[i].TimeIndex) /
+                          (Frames[i + 1].TimeIndex - Frames[i].TimeIndex);
+                return Frames[i].Value + (Frames[i + 1].Value - Frames[i].Value) * t;
+            }
+        }
+
+        return Frames[^1].Value;
+    }
+}

--- a/Tools/Source/UsagiTools/src/Usagi.ToolCore/Particles/EditableEffect.cs
+++ b/Tools/Source/UsagiTools/src/Usagi.ToolCore/Particles/EditableEffect.cs
@@ -1,0 +1,102 @@
+// Usagi.ToolCore - Particle Editor Support
+// Editable effect model (groups of emitters)
+
+namespace Usagi.ToolCore.Particles;
+
+/// <summary>
+/// A reference to an emitter within an effect group.
+/// </summary>
+public sealed class EmitterInstance
+{
+    /// <summary>
+    /// The emitter name (references an emitter YAML file).
+    /// </summary>
+    public string EmitterName { get; set; } = "";
+
+    /// <summary>
+    /// Local scale of this emitter instance.
+    /// </summary>
+    public Vec3 Scale { get; set; } = Vec3.One;
+
+    /// <summary>
+    /// Local rotation (Euler angles in degrees).
+    /// </summary>
+    public Vec3 Rotation { get; set; } = Vec3.Zero;
+
+    /// <summary>
+    /// Local position offset.
+    /// </summary>
+    public Vec3 Position { get; set; } = Vec3.Zero;
+
+    /// <summary>
+    /// Additional particle scale multiplier.
+    /// </summary>
+    public float ParticleScale { get; set; } = 1.0f;
+
+    /// <summary>
+    /// Frame at which this emitter starts releasing particles.
+    /// </summary>
+    public float ReleaseFrame { get; set; } = 0.0f;
+
+    /// <summary>
+    /// Creates a new emitter instance referencing the given emitter.
+    /// </summary>
+    public static EmitterInstance Create(string emitterName)
+    {
+        return new EmitterInstance { EmitterName = emitterName };
+    }
+}
+
+/// <summary>
+/// A complete editable particle effect (group of emitters).
+/// </summary>
+public sealed class EditableEffect
+{
+    /// <summary>
+    /// The effect name (derived from filename).
+    /// </summary>
+    public string Name { get; set; } = "NewEffect";
+
+    /// <summary>
+    /// Path to the source YAML file.
+    /// </summary>
+    public string SourcePath { get; set; } = "";
+
+    /// <summary>
+    /// The emitter instances in this effect.
+    /// </summary>
+    public List<EmitterInstance> Emitters { get; } = [];
+
+    /// <summary>
+    /// Number of particles to preload/warm up.
+    /// </summary>
+    public int PreloadCount { get; set; } = 0;
+
+    /// <summary>
+    /// Creates a new effect with a single emitter reference.
+    /// </summary>
+    public static EditableEffect CreateDefault(string name, string emitterName)
+    {
+        var effect = new EditableEffect { Name = name };
+        effect.Emitters.Add(EmitterInstance.Create(emitterName));
+        return effect;
+    }
+
+    /// <summary>
+    /// Adds an emitter instance to this effect.
+    /// </summary>
+    public EmitterInstance AddEmitter(string emitterName)
+    {
+        var instance = EmitterInstance.Create(emitterName);
+        Emitters.Add(instance);
+        return instance;
+    }
+
+    /// <summary>
+    /// Removes an emitter instance from this effect.
+    /// </summary>
+    public bool RemoveEmitter(EmitterInstance instance)
+    {
+        return Emitters.Remove(instance);
+    }
+}

--- a/Tools/Source/UsagiTools/src/Usagi.ToolCore/Particles/EditableEmitter.cs
+++ b/Tools/Source/UsagiTools/src/Usagi.ToolCore/Particles/EditableEmitter.cs
@@ -1,0 +1,310 @@
+// Usagi.ToolCore - Particle Editor Support
+// Editable emitter model
+
+namespace Usagi.ToolCore.Particles;
+
+/// <summary>
+/// Blend function values matching engine enums.
+/// </summary>
+public enum BlendFunc
+{
+    Zero = 0,
+    One = 1,
+    SrcColor = 2,
+    OneMinusSrcColor = 3,
+    DstColor = 4,
+    OneMinusDstColor = 5,
+    SrcAlpha = 6,
+    OneMinusSrcAlpha = 7,
+    DstAlpha = 8,
+    OneMinusDstAlpha = 9,
+    ConstColor = 10,
+    OneMinusConstColor = 11,
+    ConstAlpha = 12,
+    OneMinusConstAlpha = 13,
+    SrcAlphaSaturate = 14
+}
+
+/// <summary>
+/// Blend operation values.
+/// </summary>
+public enum BlendOp
+{
+    Add = 0,
+    Subtract = 1,
+    ReverseSubtract = 2,
+    Min = 3,
+    Max = 4
+}
+
+/// <summary>
+/// Particle type values.
+/// </summary>
+public enum ParticleType
+{
+    Billboard = 0,
+    DirectionOriented = 1,
+    YAxisAligned = 2,
+    VelocityAligned = 3,
+    Trail = 4
+}
+
+/// <summary>
+/// Emission type values.
+/// </summary>
+public enum EmissionType
+{
+    Continuous = 0,
+    OneShot = 1,
+    Infinite = 2
+}
+
+/// <summary>
+/// Texture animation mode.
+/// </summary>
+public enum TextureAnimMode
+{
+    None = 0,
+    Linear = 1,
+    Random = 2
+}
+
+/// <summary>
+/// Color mode for particle coloring.
+/// </summary>
+public enum ColorMode
+{
+    Constant = 0,
+    Random = 1,
+    Gradient = 2
+}
+
+/// <summary>
+/// Emitter shape type.
+/// </summary>
+public enum EmitterShape
+{
+    Point = 0,
+    Sphere = 1,
+    Box = 2,
+    Cylinder = 3,
+    Cone = 4
+}
+
+/// <summary>
+/// Blend state settings.
+/// </summary>
+public sealed class BlendSettings
+{
+    public BlendFunc RgbSrcFunc { get; set; } = BlendFunc.SrcAlpha;
+    public BlendFunc RgbDestFunc { get; set; } = BlendFunc.OneMinusSrcAlpha;
+    public BlendOp RgbOp { get; set; } = BlendOp.Add;
+    public BlendFunc AlphaSrcFunc { get; set; } = BlendFunc.One;
+    public BlendFunc AlphaDestFunc { get; set; } = BlendFunc.OneMinusSrcAlpha;
+    public BlendOp AlphaOp { get; set; } = BlendOp.Add;
+    public Color4 ConstColor { get; set; } = Color4.Clear;
+    public int AlphaTestFunc { get; set; } = 1;
+    public float AlphaTestReference { get; set; } = 0.0f;
+}
+
+/// <summary>
+/// Sort/render settings.
+/// </summary>
+public sealed class SortSettings
+{
+    public int RenderLayer { get; set; } = 1;
+    public int Priority { get; set; } = 0;
+    public bool WriteDepth { get; set; } = false;
+}
+
+/// <summary>
+/// Texture animation settings.
+/// </summary>
+public sealed class TextureAnimation
+{
+    public TextureAnimMode Mode { get; set; } = TextureAnimMode.None;
+    public bool RandomOffset { get; set; } = false;
+    public List<int> AnimIndex { get; } = [];
+    public float AnimTimeScale { get; set; } = 1.0f;
+}
+
+/// <summary>
+/// A texture slot in the emitter.
+/// </summary>
+public sealed class TextureSlot
+{
+    public string Name { get; set; } = "";
+    public int PatternRepeatHor { get; set; } = 1;
+    public int PatternRepeatVer { get; set; } = 1;
+    public TextureAnimation Animation { get; } = new();
+}
+
+/// <summary>
+/// Emission rate and timing settings.
+/// </summary>
+public sealed class EmissionSettings
+{
+    public EmissionType Type { get; set; } = EmissionType.Continuous;
+    public float EmissionTime { get; set; } = 5.0f;
+    public AnimatedFloat EmissionRate { get; } = new(10.0f);
+    public float ReleaseInterval { get; set; } = 0.0f;
+    public float ReleaseIntervalRandom { get; set; } = 0.0f;
+    public int MaxParticles { get; set; } = 128;
+    public Vec3 UserRotation { get; set; } = Vec3.Zero;
+}
+
+/// <summary>
+/// Particle color settings.
+/// </summary>
+public sealed class ParticleColorSettings
+{
+    public ColorMode Mode { get; set; } = ColorMode.Constant;
+    public Color4 Color0 { get; set; } = Color4.White;
+    public Color4 Color1 { get; set; } = Color4.White;
+    public Color4 Color2 { get; set; } = Color4.White;
+    public float InTimeEnd { get; set; } = 0.0f;
+    public float OutTimeStart { get; set; } = 1.0f;
+    public float Peak { get; set; } = 1.0f;
+    public int RepetitionCount { get; set; } = 0;
+    public bool RandomRepetitionPos { get; set; } = false;
+    public float LerpEnvColor { get; set; } = 0.0f;
+}
+
+/// <summary>
+/// Particle alpha/transparency settings.
+/// </summary>
+public sealed class ParticleAlphaSettings
+{
+    public float InitialAlpha { get; set; } = 0.0f;
+    public float IntermediateAlpha { get; set; } = 1.0f;
+    public float EndAlpha { get; set; } = 0.0f;
+    public float FinishInTime { get; set; } = 0.1f;
+    public float OutStartTiming { get; set; } = 0.9f;
+}
+
+/// <summary>
+/// Particle rotation settings.
+/// </summary>
+public sealed class ParticleRotationSettings
+{
+    public float BaseRotation { get; set; } = 0.0f;
+    public float Randomise { get; set; } = 0.0f;
+    public float Speed { get; set; } = 0.0f;
+    public float SpeedRandomise { get; set; } = 0.0f;
+}
+
+/// <summary>
+/// Particle scale settings.
+/// </summary>
+public sealed class ParticleScaleSettings
+{
+    public AnimatedFloat StandardValue { get; } = new(1.0f);
+    public float Randomness { get; set; } = 0.0f;
+    public float Initial { get; set; } = 1.0f;
+    public float Intermediate { get; set; } = 1.0f;
+    public float Ending { get; set; } = 1.0f;
+    public float BeginScaleIn { get; set; } = 0.0f;
+    public float StartScaleOut { get; set; } = 1.0f;
+}
+
+/// <summary>
+/// Base shape transform settings.
+/// </summary>
+public sealed class BaseShapeSettings
+{
+    public Vec3 Scale { get; set; } = Vec3.One;
+    public Vec3 Rotation { get; set; } = Vec3.Zero;
+    public Vec3 Position { get; set; } = Vec3.Zero;
+    public float Hollowness { get; set; } = 0.0f;
+    public Vec3 Velocity { get; set; } = Vec3.Zero;
+    public float SpeedRand { get; set; } = 0.0f;
+    public Vec3 Gravity { get; set; } = Vec3.Zero;
+    public float ShapeExpandVel { get; set; } = 0.0f;
+}
+
+/// <summary>
+/// Arc settings for circular shapes.
+/// </summary>
+public sealed class ArcSettings
+{
+    public float ArcWidthDeg { get; set; } = 360.0f;
+    public float ArcStartDeg { get; set; } = 0.0f;
+    public bool RandomizeStartAngle { get; set; } = false;
+}
+
+/// <summary>
+/// Shape details for an emitter.
+/// </summary>
+public sealed class EmitterShapeDetails
+{
+    public BaseShapeSettings BaseShape { get; } = new();
+    public ArcSettings Arc { get; } = new();
+    public Vec3 ShapeExtents { get; set; } = Vec3.Zero;
+}
+
+/// <summary>
+/// A complete editable particle emitter.
+/// </summary>
+public sealed class EditableEmitter
+{
+    /// <summary>
+    /// The emitter name (derived from filename).
+    /// </summary>
+    public string Name { get; set; } = "NewEmitter";
+
+    /// <summary>
+    /// Path to the source YAML file.
+    /// </summary>
+    public string SourcePath { get; set; } = "";
+
+    // Rendering
+    public BlendSettings Blend { get; } = new();
+    public float SoftFadeDistance { get; set; } = 0.0f;
+    public SortSettings Sort { get; } = new();
+    public List<TextureSlot> Textures { get; } = [];
+
+    // Emission
+    public EmissionSettings Emission { get; } = new();
+    public float PositionRandomness { get; set; } = 0.0f;
+
+    // Velocity
+    public AnimatedFloat OmniVelocity { get; } = new(0.0f);
+    public AnimatedFloat DirVelocity { get; } = new(0.0f);
+    public Vec3 VelocityDir { get; set; } = Vec3.Up;
+    public float VelocityDirConeDeg { get; set; } = 0.0f;
+    public float SpeedRandomness { get; set; } = 0.0f;
+    public bool InheritVelocity { get; set; } = false;
+
+    // Physics
+    public bool LocalEffect { get; set; } = true;
+    public bool CpuPositionUpdate { get; set; } = false;
+    public float Drag { get; set; } = 0.0f;
+    public float GravityStrength { get; set; } = 0.0f;
+    public Vec3 GravityDir { get; set; } = Vec3.Down;
+
+    // Particle settings
+    public ParticleType Type { get; set; } = ParticleType.Billboard;
+    public AnimatedFloat Life { get; } = new(1.0f);
+    public float LifeRandomness { get; set; } = 0.0f;
+    public Vec2 ParticleCenter { get; set; } = Vec2.Half;
+
+    // Appearance
+    public ParticleColorSettings Color { get; } = new();
+    public ParticleAlphaSettings Alpha { get; } = new();
+    public ParticleRotationSettings Rotation { get; } = new();
+    public ParticleScaleSettings Scale { get; } = new();
+
+    // Shape
+    public EmitterShape Shape { get; set; } = EmitterShape.Point;
+    public EmitterShapeDetails ShapeDetails { get; } = new();
+
+    /// <summary>
+    /// Creates a new emitter with default settings.
+    /// </summary>
+    public static EditableEmitter CreateDefault(string name = "NewEmitter")
+    {
+        var emitter = new EditableEmitter { Name = name };
+        emitter.Textures.Add(new TextureSlot { Name = "particles/default" });
+        return emitter;
+    }
+}

--- a/Tools/Source/UsagiTools/src/Usagi.ToolCore/Particles/EditableParticleDocument.cs
+++ b/Tools/Source/UsagiTools/src/Usagi.ToolCore/Particles/EditableParticleDocument.cs
@@ -1,0 +1,275 @@
+// Usagi.ToolCore - Particle Editor Support
+// Document wrapper for editable particles with command history
+
+using Usagi.ToolCore.Commands;
+
+namespace Usagi.ToolCore.Particles;
+
+/// <summary>
+/// Document wrapper for an editable emitter with undo/redo support.
+/// </summary>
+public sealed class EditableEmitterDocument
+{
+    public EditableEmitter Emitter { get; }
+    public CommandHistory History { get; } = new();
+    public bool IsDirty => History.IsDirty;
+
+    public EditableEmitterDocument(EditableEmitter emitter)
+    {
+        Emitter = emitter;
+    }
+
+    /// <summary>
+    /// Loads an emitter document from a YAML file.
+    /// </summary>
+    public static EditableEmitterDocument Load(string path)
+    {
+        var emitter = ParticleYamlParser.ParseEmitter(path);
+        return new EditableEmitterDocument(emitter);
+    }
+
+    /// <summary>
+    /// Creates a new emitter document with default settings.
+    /// </summary>
+    public static EditableEmitterDocument CreateNew(string name = "NewEmitter")
+    {
+        var emitter = EditableEmitter.CreateDefault(name);
+        return new EditableEmitterDocument(emitter);
+    }
+
+    /// <summary>
+    /// Saves the emitter to its source path.
+    /// </summary>
+    public void Save()
+    {
+        if (string.IsNullOrEmpty(Emitter.SourcePath))
+            throw new InvalidOperationException("No source path set. Use SaveAs instead.");
+
+        ParticleYamlWriter.SaveEmitter(Emitter, Emitter.SourcePath);
+        History.MarkSaved();
+    }
+
+    /// <summary>
+    /// Saves the emitter to a new path.
+    /// </summary>
+    public void SaveAs(string path)
+    {
+        Emitter.SourcePath = path;
+        Emitter.Name = Path.GetFileNameWithoutExtension(path);
+        Save();
+    }
+
+    // Command wrappers for common operations
+
+    public void SetEmissionRate(float value)
+    {
+        if (Emitter.Emission.EmissionRate.Frames.Count > 0)
+        {
+            var oldValue = Emitter.Emission.EmissionRate.Frames[0].Value;
+            History.Execute(new ActionCommand(
+                () => Emitter.Emission.EmissionRate.Frames[0].Value = value,
+                () => Emitter.Emission.EmissionRate.Frames[0].Value = oldValue,
+                $"Set emission rate to {value}"));
+        }
+    }
+
+    public void SetMaxParticles(int value)
+    {
+        var oldValue = Emitter.Emission.MaxParticles;
+        History.Execute(new ActionCommand(
+            () => Emitter.Emission.MaxParticles = value,
+            () => Emitter.Emission.MaxParticles = oldValue,
+            $"Set max particles to {value}"));
+    }
+
+    public void SetLifespan(float value)
+    {
+        if (Emitter.Life.Frames.Count > 0)
+        {
+            var oldValue = Emitter.Life.Frames[0].Value;
+            History.Execute(new ActionCommand(
+                () => Emitter.Life.Frames[0].Value = value,
+                () => Emitter.Life.Frames[0].Value = oldValue,
+                $"Set lifespan to {value}"));
+        }
+    }
+
+    public void SetShape(EmitterShape shape)
+    {
+        var oldShape = Emitter.Shape;
+        History.Execute(new ActionCommand(
+            () => Emitter.Shape = shape,
+            () => Emitter.Shape = oldShape,
+            $"Set shape to {shape}"));
+    }
+
+    public void SetTexture(int slot, string textureName)
+    {
+        while (Emitter.Textures.Count <= slot)
+        {
+            Emitter.Textures.Add(new TextureSlot());
+        }
+
+        var oldName = Emitter.Textures[slot].Name;
+        History.Execute(new ActionCommand(
+            () => Emitter.Textures[slot].Name = textureName,
+            () => Emitter.Textures[slot].Name = oldName,
+            $"Set texture {slot} to {textureName}"));
+    }
+
+    public void AddTexture(string textureName)
+    {
+        var slot = new TextureSlot { Name = textureName };
+        History.Execute(new ActionCommand(
+            () => Emitter.Textures.Add(slot),
+            () => Emitter.Textures.Remove(slot),
+            $"Add texture {textureName}"));
+    }
+
+    public void RemoveTexture(int slot)
+    {
+        if (slot < 0 || slot >= Emitter.Textures.Count) return;
+
+        var texture = Emitter.Textures[slot];
+        History.Execute(new ActionCommand(
+            () => Emitter.Textures.RemoveAt(slot),
+            () => Emitter.Textures.Insert(slot, texture),
+            $"Remove texture {texture.Name}"));
+    }
+}
+
+/// <summary>
+/// Document wrapper for an editable effect with undo/redo support.
+/// </summary>
+public sealed class EditableEffectDocument
+{
+    public EditableEffect Effect { get; }
+    public CommandHistory History { get; } = new();
+    public bool IsDirty => History.IsDirty;
+
+    public EditableEffectDocument(EditableEffect effect)
+    {
+        Effect = effect;
+    }
+
+    /// <summary>
+    /// Loads an effect document from a YAML file.
+    /// </summary>
+    public static EditableEffectDocument Load(string path)
+    {
+        var effect = ParticleYamlParser.ParseEffect(path);
+        return new EditableEffectDocument(effect);
+    }
+
+    /// <summary>
+    /// Creates a new effect document with a single emitter reference.
+    /// </summary>
+    public static EditableEffectDocument CreateNew(string name, string emitterName)
+    {
+        var effect = EditableEffect.CreateDefault(name, emitterName);
+        return new EditableEffectDocument(effect);
+    }
+
+    /// <summary>
+    /// Saves the effect to its source path.
+    /// </summary>
+    public void Save()
+    {
+        if (string.IsNullOrEmpty(Effect.SourcePath))
+            throw new InvalidOperationException("No source path set. Use SaveAs instead.");
+
+        ParticleYamlWriter.SaveEffect(Effect, Effect.SourcePath);
+        History.MarkSaved();
+    }
+
+    /// <summary>
+    /// Saves the effect to a new path.
+    /// </summary>
+    public void SaveAs(string path)
+    {
+        Effect.SourcePath = path;
+        Effect.Name = Path.GetFileNameWithoutExtension(path);
+        Save();
+    }
+
+    // Command wrappers for common operations
+
+    public EmitterInstance AddEmitter(string emitterName)
+    {
+        var instance = EmitterInstance.Create(emitterName);
+        History.Execute(new ActionCommand(
+            () => Effect.Emitters.Add(instance),
+            () => Effect.Emitters.Remove(instance),
+            $"Add emitter {emitterName}"));
+        return instance;
+    }
+
+    public void RemoveEmitter(EmitterInstance instance)
+    {
+        var index = Effect.Emitters.IndexOf(instance);
+        if (index < 0) return;
+
+        History.Execute(new ActionCommand(
+            () => Effect.Emitters.Remove(instance),
+            () => Effect.Emitters.Insert(index, instance),
+            $"Remove emitter {instance.EmitterName}"));
+    }
+
+    public void SetEmitterPosition(EmitterInstance instance, Vec3 position)
+    {
+        var oldPos = instance.Position;
+        History.Execute(new ActionCommand(
+            () => instance.Position = position,
+            () => instance.Position = oldPos,
+            $"Set {instance.EmitterName} position"));
+    }
+
+    public void SetEmitterScale(EmitterInstance instance, Vec3 scale)
+    {
+        var oldScale = instance.Scale;
+        History.Execute(new ActionCommand(
+            () => instance.Scale = scale,
+            () => instance.Scale = oldScale,
+            $"Set {instance.EmitterName} scale"));
+    }
+
+    public void SetEmitterRotation(EmitterInstance instance, Vec3 rotation)
+    {
+        var oldRot = instance.Rotation;
+        History.Execute(new ActionCommand(
+            () => instance.Rotation = rotation,
+            () => instance.Rotation = oldRot,
+            $"Set {instance.EmitterName} rotation"));
+    }
+
+    public void SetPreloadCount(int count)
+    {
+        var oldCount = Effect.PreloadCount;
+        History.Execute(new ActionCommand(
+            () => Effect.PreloadCount = count,
+            () => Effect.PreloadCount = oldCount,
+            $"Set preload count to {count}"));
+    }
+}
+
+/// <summary>
+/// Simple action-based command for particle property changes.
+/// </summary>
+internal sealed class ActionCommand : ICommand
+{
+    private readonly Action _execute;
+    private readonly Action _undo;
+    private readonly string _description;
+
+    public ActionCommand(Action execute, Action undo, string description)
+    {
+        _execute = execute;
+        _undo = undo;
+        _description = description;
+    }
+
+    public string Description => _description;
+    public void Execute() => _execute();
+    public void Undo() => _undo();
+    public override string ToString() => _description;
+}

--- a/Tools/Source/UsagiTools/src/Usagi.ToolCore/Particles/ParticleYamlParser.cs
+++ b/Tools/Source/UsagiTools/src/Usagi.ToolCore/Particles/ParticleYamlParser.cs
@@ -1,0 +1,673 @@
+// Usagi.ToolCore - Particle Editor Support
+// YAML parser for emitter and effect files
+
+using System.Globalization;
+using YamlDotNet.RepresentationModel;
+
+namespace Usagi.ToolCore.Particles;
+
+/// <summary>
+/// Parses particle emitter and effect YAML files.
+/// </summary>
+public static class ParticleYamlParser
+{
+    /// <summary>
+    /// Parses an emitter from a YAML file.
+    /// </summary>
+    public static EditableEmitter ParseEmitter(string path)
+    {
+        var content = File.ReadAllText(path);
+        return ParseEmitterFromYaml(content, path);
+    }
+
+    /// <summary>
+    /// Parses an emitter from YAML content.
+    /// </summary>
+    public static EditableEmitter ParseEmitterFromYaml(string yaml, string sourcePath = "")
+    {
+        var emitter = new EditableEmitter
+        {
+            SourcePath = sourcePath,
+            Name = Path.GetFileNameWithoutExtension(sourcePath)
+        };
+
+        var input = new StringReader(yaml);
+        var yamlStream = new YamlStream();
+        yamlStream.Load(input);
+
+        // Emitter files have two documents: EmitterEmission and EmitterShapeDetails
+        foreach (var doc in yamlStream.Documents)
+        {
+            if (doc.RootNode is YamlMappingNode root)
+            {
+                foreach (var entry in root.Children)
+                {
+                    var key = GetScalarValue(entry.Key);
+                    if (key == "Particles.EmitterEmission" && entry.Value is YamlMappingNode emission)
+                    {
+                        ParseEmitterEmission(emission, emitter);
+                    }
+                    else if (key == "Particles.EmitterShapeDetails" && entry.Value is YamlMappingNode shape)
+                    {
+                        ParseEmitterShapeDetails(shape, emitter.ShapeDetails);
+                    }
+                }
+            }
+        }
+
+        return emitter;
+    }
+
+    /// <summary>
+    /// Parses an effect from a YAML file.
+    /// </summary>
+    public static EditableEffect ParseEffect(string path)
+    {
+        var content = File.ReadAllText(path);
+        return ParseEffectFromYaml(content, path);
+    }
+
+    /// <summary>
+    /// Parses an effect from YAML content.
+    /// </summary>
+    public static EditableEffect ParseEffectFromYaml(string yaml, string sourcePath = "")
+    {
+        var effect = new EditableEffect
+        {
+            SourcePath = sourcePath,
+            Name = Path.GetFileNameWithoutExtension(sourcePath)
+        };
+
+        var input = new StringReader(yaml);
+        var yamlStream = new YamlStream();
+        yamlStream.Load(input);
+
+        if (yamlStream.Documents.Count > 0 && yamlStream.Documents[0].RootNode is YamlMappingNode root)
+        {
+            foreach (var entry in root.Children)
+            {
+                var key = GetScalarValue(entry.Key);
+                if (key == "Particles.EffectGroup" && entry.Value is YamlMappingNode group)
+                {
+                    ParseEffectGroup(group, effect);
+                }
+            }
+        }
+
+        return effect;
+    }
+
+    private static void ParseEmitterEmission(YamlMappingNode node, EditableEmitter emitter)
+    {
+        foreach (var entry in node.Children)
+        {
+            var key = GetScalarValue(entry.Key);
+            switch (key)
+            {
+                case "blend" when entry.Value is YamlMappingNode blend:
+                    ParseBlendSettings(blend, emitter.Blend);
+                    break;
+                case "fSoftFadeDistance":
+                    emitter.SoftFadeDistance = GetFloat(entry.Value);
+                    break;
+                case "sortSettings" when entry.Value is YamlMappingNode sort:
+                    ParseSortSettings(sort, emitter.Sort);
+                    break;
+                case "textureData" when entry.Value is YamlSequenceNode textures:
+                    ParseTextures(textures, emitter.Textures);
+                    break;
+                case "emission" when entry.Value is YamlMappingNode emission:
+                    ParseEmissionSettings(emission, emitter.Emission);
+                    break;
+                case "fPositionRandomness":
+                    emitter.PositionRandomness = GetFloat(entry.Value);
+                    break;
+                case "omniVelocity" when entry.Value is YamlMappingNode omni:
+                    ParseAnimatedFloat(omni, emitter.OmniVelocity);
+                    break;
+                case "dirVelocity" when entry.Value is YamlMappingNode dir:
+                    ParseAnimatedFloat(dir, emitter.DirVelocity);
+                    break;
+                case "vVelocityDir" when entry.Value is YamlMappingNode vec:
+                    emitter.VelocityDir = ParseVec3(vec);
+                    break;
+                case "fVelocityDirConeDeg":
+                    emitter.VelocityDirConeDeg = GetFloat(entry.Value);
+                    break;
+                case "fSpeedRandomness":
+                    emitter.SpeedRandomness = GetFloat(entry.Value);
+                    break;
+                case "bInheritVelocity":
+                    emitter.InheritVelocity = GetBool(entry.Value);
+                    break;
+                case "bLocalEffect":
+                    emitter.LocalEffect = GetBool(entry.Value);
+                    break;
+                case "bCPUPositionUpdate":
+                    emitter.CpuPositionUpdate = GetBool(entry.Value);
+                    break;
+                case "fDrag":
+                    emitter.Drag = GetFloat(entry.Value);
+                    break;
+                case "fGravityStrength":
+                    emitter.GravityStrength = GetFloat(entry.Value);
+                    break;
+                case "vGravityDir" when entry.Value is YamlMappingNode grav:
+                    emitter.GravityDir = ParseVec3(grav);
+                    break;
+                case "eParticleType":
+                    emitter.Type = (ParticleType)GetInt(entry.Value);
+                    break;
+                case "life" when entry.Value is YamlMappingNode life:
+                    ParseAnimatedFloat(life, emitter.Life);
+                    break;
+                case "fLifeRandomness":
+                    emitter.LifeRandomness = GetFloat(entry.Value);
+                    break;
+                case "vParticleCenter" when entry.Value is YamlMappingNode center:
+                    emitter.ParticleCenter = ParseVec2(center);
+                    break;
+                case "particleColor" when entry.Value is YamlMappingNode color:
+                    ParseParticleColor(color, emitter.Color);
+                    break;
+                case "particleAlpha" when entry.Value is YamlMappingNode alpha:
+                    ParseParticleAlpha(alpha, emitter.Alpha);
+                    break;
+                case "particleRotation" when entry.Value is YamlMappingNode rot:
+                    ParseParticleRotation(rot, emitter.Rotation);
+                    break;
+                case "particleScale" when entry.Value is YamlMappingNode scale:
+                    ParseParticleScale(scale, emitter.Scale);
+                    break;
+                case "eShape":
+                    emitter.Shape = (EmitterShape)GetInt(entry.Value);
+                    break;
+            }
+        }
+    }
+
+    private static void ParseBlendSettings(YamlMappingNode node, BlendSettings blend)
+    {
+        foreach (var entry in node.Children)
+        {
+            var key = GetScalarValue(entry.Key);
+            switch (key)
+            {
+                case "rgbSrcFunc":
+                    blend.RgbSrcFunc = (BlendFunc)GetInt(entry.Value);
+                    break;
+                case "rgbDestFunc":
+                    blend.RgbDestFunc = (BlendFunc)GetInt(entry.Value);
+                    break;
+                case "rgbOp":
+                    blend.RgbOp = (BlendOp)GetInt(entry.Value);
+                    break;
+                case "alphaSrcFunc":
+                    blend.AlphaSrcFunc = (BlendFunc)GetInt(entry.Value);
+                    break;
+                case "alphaDestFunc":
+                    blend.AlphaDestFunc = (BlendFunc)GetInt(entry.Value);
+                    break;
+                case "alphaOp":
+                    blend.AlphaOp = (BlendOp)GetInt(entry.Value);
+                    break;
+                case "constColor" when entry.Value is YamlMappingNode color:
+                    blend.ConstColor = ParseColor4(color);
+                    break;
+                case "alphaTestFunc":
+                    blend.AlphaTestFunc = GetInt(entry.Value);
+                    break;
+                case "alphaTestReference":
+                    blend.AlphaTestReference = GetFloat(entry.Value);
+                    break;
+            }
+        }
+    }
+
+    private static void ParseSortSettings(YamlMappingNode node, SortSettings sort)
+    {
+        foreach (var entry in node.Children)
+        {
+            var key = GetScalarValue(entry.Key);
+            switch (key)
+            {
+                case "eRenderLayer":
+                    sort.RenderLayer = GetInt(entry.Value);
+                    break;
+                case "uPriority":
+                    sort.Priority = GetInt(entry.Value);
+                    break;
+                case "bWriteDepth":
+                    sort.WriteDepth = GetBool(entry.Value);
+                    break;
+            }
+        }
+    }
+
+    private static void ParseTextures(YamlSequenceNode node, List<TextureSlot> textures)
+    {
+        foreach (var item in node.Children)
+        {
+            if (item is YamlMappingNode tex)
+            {
+                var slot = new TextureSlot();
+                foreach (var entry in tex.Children)
+                {
+                    var key = GetScalarValue(entry.Key);
+                    switch (key)
+                    {
+                        case "name":
+                            slot.Name = GetScalarValue(entry.Value);
+                            break;
+                        case "uPatternRepeatHor":
+                            slot.PatternRepeatHor = GetInt(entry.Value);
+                            break;
+                        case "uPatternRepeatVer":
+                            slot.PatternRepeatVer = GetInt(entry.Value);
+                            break;
+                        case "textureAnim" when entry.Value is YamlMappingNode anim:
+                            ParseTextureAnimation(anim, slot.Animation);
+                            break;
+                    }
+                }
+                textures.Add(slot);
+            }
+        }
+    }
+
+    private static void ParseTextureAnimation(YamlMappingNode node, TextureAnimation anim)
+    {
+        foreach (var entry in node.Children)
+        {
+            var key = GetScalarValue(entry.Key);
+            switch (key)
+            {
+                case "eTexMode":
+                    anim.Mode = (TextureAnimMode)GetInt(entry.Value);
+                    break;
+                case "bRandomOffset":
+                    anim.RandomOffset = GetBool(entry.Value);
+                    break;
+                case "animIndex" when entry.Value is YamlSequenceNode indices:
+                    anim.AnimIndex.Clear();
+                    foreach (var idx in indices.Children)
+                    {
+                        anim.AnimIndex.Add(GetInt(idx));
+                    }
+                    break;
+                case "fAnimTimeScale":
+                    anim.AnimTimeScale = GetFloat(entry.Value);
+                    break;
+            }
+        }
+    }
+
+    private static void ParseEmissionSettings(YamlMappingNode node, EmissionSettings emission)
+    {
+        foreach (var entry in node.Children)
+        {
+            var key = GetScalarValue(entry.Key);
+            switch (key)
+            {
+                case "eEmissionType":
+                    emission.Type = (EmissionType)GetInt(entry.Value);
+                    break;
+                case "fEmissionTime":
+                    emission.EmissionTime = GetFloat(entry.Value);
+                    break;
+                case "emissionRate" when entry.Value is YamlMappingNode rate:
+                    ParseAnimatedFloat(rate, emission.EmissionRate);
+                    break;
+                case "fReleaseInterval":
+                    emission.ReleaseInterval = GetFloat(entry.Value);
+                    break;
+                case "fReleaseIntervalRandom":
+                    emission.ReleaseIntervalRandom = GetFloat(entry.Value);
+                    break;
+                case "uMaxParticles":
+                    emission.MaxParticles = GetInt(entry.Value);
+                    break;
+                case "vUserRotation" when entry.Value is YamlMappingNode rot:
+                    emission.UserRotation = ParseVec3(rot);
+                    break;
+            }
+        }
+    }
+
+    private static void ParseAnimatedFloat(YamlMappingNode node, AnimatedFloat anim)
+    {
+        anim.Frames.Clear();
+        if (node.Children.TryGetValue(new YamlScalarNode("frames"), out var framesNode)
+            && framesNode is YamlSequenceNode frames)
+        {
+            foreach (var frame in frames.Children)
+            {
+                if (frame is YamlMappingNode frameNode)
+                {
+                    var keyframe = new Keyframe();
+                    foreach (var entry in frameNode.Children)
+                    {
+                        var key = GetScalarValue(entry.Key);
+                        switch (key)
+                        {
+                            case "fTimeIndex":
+                                keyframe.TimeIndex = GetFloat(entry.Value);
+                                break;
+                            case "fValue":
+                                keyframe.Value = GetFloat(entry.Value);
+                                break;
+                        }
+                    }
+                    anim.Frames.Add(keyframe);
+                }
+            }
+        }
+    }
+
+    private static void ParseParticleColor(YamlMappingNode node, ParticleColorSettings color)
+    {
+        foreach (var entry in node.Children)
+        {
+            var key = GetScalarValue(entry.Key);
+            switch (key)
+            {
+                case "eColorMode":
+                    color.Mode = (ColorMode)GetInt(entry.Value);
+                    break;
+                case "cColor0" when entry.Value is YamlMappingNode c:
+                    color.Color0 = ParseColor4(c);
+                    break;
+                case "cColor1" when entry.Value is YamlMappingNode c:
+                    color.Color1 = ParseColor4(c);
+                    break;
+                case "cColor2" when entry.Value is YamlMappingNode c:
+                    color.Color2 = ParseColor4(c);
+                    break;
+                case "fInTimeEnd":
+                    color.InTimeEnd = GetFloat(entry.Value);
+                    break;
+                case "fOutTimeStart":
+                    color.OutTimeStart = GetFloat(entry.Value);
+                    break;
+                case "fPeak":
+                    color.Peak = GetFloat(entry.Value);
+                    break;
+                case "uRepetitionCount":
+                    color.RepetitionCount = GetInt(entry.Value);
+                    break;
+                case "bRandomRepetitionPos":
+                    color.RandomRepetitionPos = GetBool(entry.Value);
+                    break;
+                case "fLerpEnvColor":
+                    color.LerpEnvColor = GetFloat(entry.Value);
+                    break;
+            }
+        }
+    }
+
+    private static void ParseParticleAlpha(YamlMappingNode node, ParticleAlphaSettings alpha)
+    {
+        foreach (var entry in node.Children)
+        {
+            var key = GetScalarValue(entry.Key);
+            switch (key)
+            {
+                case "fInitialAlpha":
+                    alpha.InitialAlpha = GetFloat(entry.Value);
+                    break;
+                case "fIntermediateAlpha":
+                    alpha.IntermediateAlpha = GetFloat(entry.Value);
+                    break;
+                case "fEndAlpha":
+                    alpha.EndAlpha = GetFloat(entry.Value);
+                    break;
+                case "fFinishInTime":
+                    alpha.FinishInTime = GetFloat(entry.Value);
+                    break;
+                case "fOutStartTiming":
+                    alpha.OutStartTiming = GetFloat(entry.Value);
+                    break;
+            }
+        }
+    }
+
+    private static void ParseParticleRotation(YamlMappingNode node, ParticleRotationSettings rot)
+    {
+        foreach (var entry in node.Children)
+        {
+            var key = GetScalarValue(entry.Key);
+            switch (key)
+            {
+                case "fBaseRotation":
+                    rot.BaseRotation = GetFloat(entry.Value);
+                    break;
+                case "fRandomise":
+                    rot.Randomise = GetFloat(entry.Value);
+                    break;
+                case "fSpeed":
+                    rot.Speed = GetFloat(entry.Value);
+                    break;
+                case "fSpeedRandomise":
+                    rot.SpeedRandomise = GetFloat(entry.Value);
+                    break;
+            }
+        }
+    }
+
+    private static void ParseParticleScale(YamlMappingNode node, ParticleScaleSettings scale)
+    {
+        foreach (var entry in node.Children)
+        {
+            var key = GetScalarValue(entry.Key);
+            switch (key)
+            {
+                case "standardValue" when entry.Value is YamlMappingNode std:
+                    ParseAnimatedFloat(std, scale.StandardValue);
+                    break;
+                case "fRandomness":
+                    scale.Randomness = GetFloat(entry.Value);
+                    break;
+                case "fInitial":
+                    scale.Initial = GetFloat(entry.Value);
+                    break;
+                case "fIntermediate":
+                    scale.Intermediate = GetFloat(entry.Value);
+                    break;
+                case "fEnding":
+                    scale.Ending = GetFloat(entry.Value);
+                    break;
+                case "fBeginScaleIn":
+                    scale.BeginScaleIn = GetFloat(entry.Value);
+                    break;
+                case "fStartScaleOut":
+                    scale.StartScaleOut = GetFloat(entry.Value);
+                    break;
+            }
+        }
+    }
+
+    private static void ParseEmitterShapeDetails(YamlMappingNode node, EmitterShapeDetails details)
+    {
+        foreach (var entry in node.Children)
+        {
+            var key = GetScalarValue(entry.Key);
+            switch (key)
+            {
+                case "baseShape" when entry.Value is YamlMappingNode shape:
+                    ParseBaseShape(shape, details.BaseShape);
+                    break;
+                case "arc" when entry.Value is YamlMappingNode arc:
+                    ParseArc(arc, details.Arc);
+                    break;
+                case "vShapeExtents" when entry.Value is YamlMappingNode ext:
+                    details.ShapeExtents = ParseVec3(ext);
+                    break;
+            }
+        }
+    }
+
+    private static void ParseBaseShape(YamlMappingNode node, BaseShapeSettings shape)
+    {
+        foreach (var entry in node.Children)
+        {
+            var key = GetScalarValue(entry.Key);
+            switch (key)
+            {
+                case "vScale" when entry.Value is YamlMappingNode v:
+                    shape.Scale = ParseVec3(v);
+                    break;
+                case "vRotation" when entry.Value is YamlMappingNode v:
+                    shape.Rotation = ParseVec3(v);
+                    break;
+                case "vPosition" when entry.Value is YamlMappingNode v:
+                    shape.Position = ParseVec3(v);
+                    break;
+                case "fHollowness":
+                    shape.Hollowness = GetFloat(entry.Value);
+                    break;
+                case "vVelocity" when entry.Value is YamlMappingNode v:
+                    shape.Velocity = ParseVec3(v);
+                    break;
+                case "fSpeedRand":
+                    shape.SpeedRand = GetFloat(entry.Value);
+                    break;
+                case "vGravity" when entry.Value is YamlMappingNode v:
+                    shape.Gravity = ParseVec3(v);
+                    break;
+                case "fShapeExpandVel":
+                    shape.ShapeExpandVel = GetFloat(entry.Value);
+                    break;
+            }
+        }
+    }
+
+    private static void ParseArc(YamlMappingNode node, ArcSettings arc)
+    {
+        foreach (var entry in node.Children)
+        {
+            var key = GetScalarValue(entry.Key);
+            switch (key)
+            {
+                case "fArcWidthDeg":
+                    arc.ArcWidthDeg = GetFloat(entry.Value);
+                    break;
+                case "fArcStartDeg":
+                    arc.ArcStartDeg = GetFloat(entry.Value);
+                    break;
+                case "bRandomizeStartAngle":
+                    arc.RandomizeStartAngle = GetBool(entry.Value);
+                    break;
+            }
+        }
+    }
+
+    private static void ParseEffectGroup(YamlMappingNode node, EditableEffect effect)
+    {
+        foreach (var entry in node.Children)
+        {
+            var key = GetScalarValue(entry.Key);
+            switch (key)
+            {
+                case "emitters" when entry.Value is YamlSequenceNode emitters:
+                    foreach (var item in emitters.Children)
+                    {
+                        if (item is YamlMappingNode em)
+                        {
+                            var instance = new EmitterInstance();
+                            foreach (var e in em.Children)
+                            {
+                                var k = GetScalarValue(e.Key);
+                                switch (k)
+                                {
+                                    case "emitterName":
+                                        instance.EmitterName = GetScalarValue(e.Value);
+                                        break;
+                                    case "vScale" when e.Value is YamlMappingNode v:
+                                        instance.Scale = ParseVec3(v);
+                                        break;
+                                    case "vRotation" when e.Value is YamlMappingNode v:
+                                        instance.Rotation = ParseVec3(v);
+                                        break;
+                                    case "vPosition" when e.Value is YamlMappingNode v:
+                                        instance.Position = ParseVec3(v);
+                                        break;
+                                    case "fParticleScale":
+                                        instance.ParticleScale = GetFloat(e.Value);
+                                        break;
+                                    case "fReleaseFrame":
+                                        instance.ReleaseFrame = GetFloat(e.Value);
+                                        break;
+                                }
+                            }
+                            effect.Emitters.Add(instance);
+                        }
+                    }
+                    break;
+                case "uPreloadCount":
+                    effect.PreloadCount = GetInt(entry.Value);
+                    break;
+            }
+        }
+    }
+
+    // Helper methods
+    private static string GetScalarValue(YamlNode node) =>
+        node is YamlScalarNode scalar ? scalar.Value ?? "" : "";
+
+    private static int GetInt(YamlNode node) =>
+        int.TryParse(GetScalarValue(node), NumberStyles.Integer, CultureInfo.InvariantCulture, out var val) ? val : 0;
+
+    private static float GetFloat(YamlNode node) =>
+        float.TryParse(GetScalarValue(node), NumberStyles.Float, CultureInfo.InvariantCulture, out var val) ? val : 0f;
+
+    private static bool GetBool(YamlNode node) =>
+        GetScalarValue(node).Equals("true", StringComparison.OrdinalIgnoreCase);
+
+    private static Vec3 ParseVec3(YamlMappingNode node)
+    {
+        var vec = Vec3.Zero;
+        foreach (var entry in node.Children)
+        {
+            var key = GetScalarValue(entry.Key);
+            switch (key)
+            {
+                case "x": vec.X = GetFloat(entry.Value); break;
+                case "y": vec.Y = GetFloat(entry.Value); break;
+                case "z": vec.Z = GetFloat(entry.Value); break;
+            }
+        }
+        return vec;
+    }
+
+    private static Vec2 ParseVec2(YamlMappingNode node)
+    {
+        var vec = Vec2.Zero;
+        foreach (var entry in node.Children)
+        {
+            var key = GetScalarValue(entry.Key);
+            switch (key)
+            {
+                case "x": vec.X = GetFloat(entry.Value); break;
+                case "y": vec.Y = GetFloat(entry.Value); break;
+            }
+        }
+        return vec;
+    }
+
+    private static Color4 ParseColor4(YamlMappingNode node)
+    {
+        var color = Color4.Clear;
+        foreach (var entry in node.Children)
+        {
+            var key = GetScalarValue(entry.Key);
+            switch (key)
+            {
+                case "m_fR": color.R = GetFloat(entry.Value); break;
+                case "m_fG": color.G = GetFloat(entry.Value); break;
+                case "m_fB": color.B = GetFloat(entry.Value); break;
+                case "m_fA": color.A = GetFloat(entry.Value); break;
+            }
+        }
+        return color;
+    }
+}

--- a/Tools/Source/UsagiTools/src/Usagi.ToolCore/Particles/ParticleYamlWriter.cs
+++ b/Tools/Source/UsagiTools/src/Usagi.ToolCore/Particles/ParticleYamlWriter.cs
@@ -1,0 +1,292 @@
+// Usagi.ToolCore - Particle Editor Support
+// YAML writer for emitter and effect files
+
+using System.Globalization;
+using System.Text;
+
+namespace Usagi.ToolCore.Particles;
+
+/// <summary>
+/// Writes particle emitter and effect data to YAML.
+/// </summary>
+public static class ParticleYamlWriter
+{
+    /// <summary>
+    /// Saves an emitter to a YAML file.
+    /// </summary>
+    public static void SaveEmitter(EditableEmitter emitter, string path)
+    {
+        var yaml = WriteEmitter(emitter);
+        File.WriteAllText(path, yaml);
+    }
+
+    /// <summary>
+    /// Writes an emitter to YAML string.
+    /// </summary>
+    public static string WriteEmitter(EditableEmitter emitter)
+    {
+        var sb = new StringBuilder();
+
+        // Write EmitterEmission document
+        sb.AppendLine("Particles.EmitterEmission:");
+        WriteEmitterEmission(sb, emitter, "  ");
+
+        // Document separator
+        sb.AppendLine("---");
+
+        // Write EmitterShapeDetails document
+        sb.AppendLine("Particles.EmitterShapeDetails:");
+        WriteEmitterShapeDetails(sb, emitter.ShapeDetails, "  ");
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Saves an effect to a YAML file.
+    /// </summary>
+    public static void SaveEffect(EditableEffect effect, string path)
+    {
+        var yaml = WriteEffect(effect);
+        File.WriteAllText(path, yaml);
+    }
+
+    /// <summary>
+    /// Writes an effect to YAML string.
+    /// </summary>
+    public static string WriteEffect(EditableEffect effect)
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine("Particles.EffectGroup:");
+        sb.AppendLine("  emitters:");
+
+        foreach (var em in effect.Emitters)
+        {
+            sb.AppendLine($"    - emitterName: {em.EmitterName}");
+            WriteVec3(sb, "vScale", em.Scale, "      ");
+            WriteVec3(sb, "vRotation", em.Rotation, "      ");
+            WriteVec3(sb, "vPosition", em.Position, "      ");
+            sb.AppendLine($"      fParticleScale: {F(em.ParticleScale)}");
+            sb.AppendLine($"      fReleaseFrame: {F(em.ReleaseFrame)}");
+        }
+
+        sb.AppendLine($"  uPreloadCount: {effect.PreloadCount}");
+
+        return sb.ToString();
+    }
+
+    private static void WriteEmitterEmission(StringBuilder sb, EditableEmitter emitter, string indent)
+    {
+        // Blend settings
+        sb.AppendLine($"{indent}blend:");
+        WriteBlendSettings(sb, emitter.Blend, indent + "  ");
+
+        sb.AppendLine($"{indent}fSoftFadeDistance: {F(emitter.SoftFadeDistance)}");
+
+        // Sort settings
+        sb.AppendLine($"{indent}sortSettings:");
+        WriteSortSettings(sb, emitter.Sort, indent + "  ");
+
+        // Textures
+        sb.AppendLine($"{indent}textureData:");
+        foreach (var tex in emitter.Textures)
+        {
+            sb.AppendLine($"{indent}  - name: {tex.Name}");
+            sb.AppendLine($"{indent}    uPatternRepeatHor: {tex.PatternRepeatHor}");
+            sb.AppendLine($"{indent}    uPatternRepeatVer: {tex.PatternRepeatVer}");
+            sb.AppendLine($"{indent}    textureAnim:");
+            sb.AppendLine($"{indent}      eTexMode: {(int)tex.Animation.Mode}");
+            sb.AppendLine($"{indent}      bRandomOffset: {B(tex.Animation.RandomOffset)}");
+            if (tex.Animation.AnimIndex.Count > 0)
+            {
+                sb.AppendLine($"{indent}      animIndex: [{string.Join(", ", tex.Animation.AnimIndex)}]");
+            }
+            else
+            {
+                sb.AppendLine($"{indent}      animIndex: []");
+            }
+            sb.AppendLine($"{indent}      fAnimTimeScale: {F(tex.Animation.AnimTimeScale)}");
+        }
+
+        // Emission
+        sb.AppendLine($"{indent}emission:");
+        WriteEmissionSettings(sb, emitter.Emission, indent + "  ");
+
+        sb.AppendLine($"{indent}fPositionRandomness: {F(emitter.PositionRandomness)}");
+
+        // Velocity
+        WriteAnimatedFloat(sb, "omniVelocity", emitter.OmniVelocity, indent);
+        WriteAnimatedFloat(sb, "dirVelocity", emitter.DirVelocity, indent);
+        WriteVec3(sb, "vVelocityDir", emitter.VelocityDir, indent);
+        sb.AppendLine($"{indent}fVelocityDirConeDeg: {F(emitter.VelocityDirConeDeg)}");
+        sb.AppendLine($"{indent}fSpeedRandomness: {F(emitter.SpeedRandomness)}");
+        sb.AppendLine($"{indent}bInheritVelocity: {B(emitter.InheritVelocity)}");
+        sb.AppendLine($"{indent}bLocalEffect: {B(emitter.LocalEffect)}");
+        sb.AppendLine($"{indent}bCPUPositionUpdate: {B(emitter.CpuPositionUpdate)}");
+        sb.AppendLine($"{indent}fDrag: {F(emitter.Drag)}");
+        sb.AppendLine($"{indent}fGravityStrength: {F(emitter.GravityStrength)}");
+        WriteVec3(sb, "vGravityDir", emitter.GravityDir, indent);
+
+        // Particle settings
+        sb.AppendLine($"{indent}eParticleType: {(int)emitter.Type}");
+        WriteAnimatedFloat(sb, "life", emitter.Life, indent);
+        sb.AppendLine($"{indent}fLifeRandomness: {F(emitter.LifeRandomness)}");
+        WriteVec2(sb, "vParticleCenter", emitter.ParticleCenter, indent);
+
+        // Color
+        sb.AppendLine($"{indent}particleColor:");
+        WriteParticleColor(sb, emitter.Color, indent + "  ");
+
+        // Alpha
+        sb.AppendLine($"{indent}particleAlpha:");
+        WriteParticleAlpha(sb, emitter.Alpha, indent + "  ");
+
+        // Rotation
+        sb.AppendLine($"{indent}particleRotation:");
+        WriteParticleRotation(sb, emitter.Rotation, indent + "  ");
+
+        // Scale
+        sb.AppendLine($"{indent}particleScale:");
+        WriteParticleScale(sb, emitter.Scale, indent + "  ");
+
+        // Shape
+        sb.AppendLine($"{indent}eShape: {(int)emitter.Shape}");
+    }
+
+    private static void WriteBlendSettings(StringBuilder sb, BlendSettings blend, string indent)
+    {
+        sb.AppendLine($"{indent}rgbSrcFunc: {(int)blend.RgbSrcFunc}");
+        sb.AppendLine($"{indent}rgbDestFunc: {(int)blend.RgbDestFunc}");
+        sb.AppendLine($"{indent}rgbOp: {(int)blend.RgbOp}");
+        sb.AppendLine($"{indent}alphaSrcFunc: {(int)blend.AlphaSrcFunc}");
+        sb.AppendLine($"{indent}alphaDestFunc: {(int)blend.AlphaDestFunc}");
+        sb.AppendLine($"{indent}alphaOp: {(int)blend.AlphaOp}");
+        WriteColor4(sb, "constColor", blend.ConstColor, indent);
+        sb.AppendLine($"{indent}alphaTestFunc: {blend.AlphaTestFunc}");
+        sb.AppendLine($"{indent}alphaTestReference: {F(blend.AlphaTestReference)}");
+    }
+
+    private static void WriteSortSettings(StringBuilder sb, SortSettings sort, string indent)
+    {
+        sb.AppendLine($"{indent}eRenderLayer: {sort.RenderLayer}");
+        sb.AppendLine($"{indent}uPriority: {sort.Priority}");
+        sb.AppendLine($"{indent}bWriteDepth: {B(sort.WriteDepth)}");
+    }
+
+    private static void WriteEmissionSettings(StringBuilder sb, EmissionSettings emission, string indent)
+    {
+        sb.AppendLine($"{indent}eEmissionType: {(int)emission.Type}");
+        sb.AppendLine($"{indent}fEmissionTime: {F(emission.EmissionTime)}");
+        WriteAnimatedFloat(sb, "emissionRate", emission.EmissionRate, indent);
+        sb.AppendLine($"{indent}fReleaseInterval: {F(emission.ReleaseInterval)}");
+        sb.AppendLine($"{indent}fReleaseIntervalRandom: {F(emission.ReleaseIntervalRandom)}");
+        sb.AppendLine($"{indent}uMaxParticles: {emission.MaxParticles}");
+        WriteVec3(sb, "vUserRotation", emission.UserRotation, indent);
+    }
+
+    private static void WriteParticleColor(StringBuilder sb, ParticleColorSettings color, string indent)
+    {
+        sb.AppendLine($"{indent}eColorMode: {(int)color.Mode}");
+        WriteColor4(sb, "cColor0", color.Color0, indent);
+        WriteColor4(sb, "cColor1", color.Color1, indent);
+        WriteColor4(sb, "cColor2", color.Color2, indent);
+        sb.AppendLine($"{indent}fInTimeEnd: {F(color.InTimeEnd)}");
+        sb.AppendLine($"{indent}fOutTimeStart: {F(color.OutTimeStart)}");
+        sb.AppendLine($"{indent}fPeak: {F(color.Peak)}");
+        sb.AppendLine($"{indent}uRepetitionCount: {color.RepetitionCount}");
+        sb.AppendLine($"{indent}bRandomRepetitionPos: {B(color.RandomRepetitionPos)}");
+        sb.AppendLine($"{indent}fLerpEnvColor: {F(color.LerpEnvColor)}");
+    }
+
+    private static void WriteParticleAlpha(StringBuilder sb, ParticleAlphaSettings alpha, string indent)
+    {
+        sb.AppendLine($"{indent}fInitialAlpha: {F(alpha.InitialAlpha)}");
+        sb.AppendLine($"{indent}fIntermediateAlpha: {F(alpha.IntermediateAlpha)}");
+        sb.AppendLine($"{indent}fEndAlpha: {F(alpha.EndAlpha)}");
+        sb.AppendLine($"{indent}fFinishInTime: {F(alpha.FinishInTime)}");
+        sb.AppendLine($"{indent}fOutStartTiming: {F(alpha.OutStartTiming)}");
+    }
+
+    private static void WriteParticleRotation(StringBuilder sb, ParticleRotationSettings rot, string indent)
+    {
+        sb.AppendLine($"{indent}fBaseRotation: {F(rot.BaseRotation)}");
+        sb.AppendLine($"{indent}fRandomise: {F(rot.Randomise)}");
+        sb.AppendLine($"{indent}fSpeed: {F(rot.Speed)}");
+        sb.AppendLine($"{indent}fSpeedRandomise: {F(rot.SpeedRandomise)}");
+    }
+
+    private static void WriteParticleScale(StringBuilder sb, ParticleScaleSettings scale, string indent)
+    {
+        WriteAnimatedFloat(sb, "standardValue", scale.StandardValue, indent);
+        sb.AppendLine($"{indent}fRandomness: {F(scale.Randomness)}");
+        sb.AppendLine($"{indent}fInitial: {F(scale.Initial)}");
+        sb.AppendLine($"{indent}fIntermediate: {F(scale.Intermediate)}");
+        sb.AppendLine($"{indent}fEnding: {F(scale.Ending)}");
+        sb.AppendLine($"{indent}fBeginScaleIn: {F(scale.BeginScaleIn)}");
+        sb.AppendLine($"{indent}fStartScaleOut: {F(scale.StartScaleOut)}");
+    }
+
+    private static void WriteEmitterShapeDetails(StringBuilder sb, EmitterShapeDetails details, string indent)
+    {
+        sb.AppendLine($"{indent}baseShape:");
+        var bi = indent + "  ";
+        WriteVec3(sb, "vScale", details.BaseShape.Scale, bi);
+        WriteVec3(sb, "vRotation", details.BaseShape.Rotation, bi);
+        WriteVec3(sb, "vPosition", details.BaseShape.Position, bi);
+        sb.AppendLine($"{bi}fHollowness: {F(details.BaseShape.Hollowness)}");
+        WriteVec3(sb, "vVelocity", details.BaseShape.Velocity, bi);
+        sb.AppendLine($"{bi}fSpeedRand: {F(details.BaseShape.SpeedRand)}");
+        WriteVec3(sb, "vGravity", details.BaseShape.Gravity, bi);
+        sb.AppendLine($"{bi}fShapeExpandVel: {F(details.BaseShape.ShapeExpandVel)}");
+
+        sb.AppendLine($"{indent}arc:");
+        var ai = indent + "  ";
+        sb.AppendLine($"{ai}fArcWidthDeg: {F(details.Arc.ArcWidthDeg)}");
+        sb.AppendLine($"{ai}fArcStartDeg: {F(details.Arc.ArcStartDeg)}");
+        sb.AppendLine($"{ai}bRandomizeStartAngle: {B(details.Arc.RandomizeStartAngle)}");
+
+        WriteVec3(sb, "vShapeExtents", details.ShapeExtents, indent);
+    }
+
+    private static void WriteAnimatedFloat(StringBuilder sb, string name, AnimatedFloat anim, string indent)
+    {
+        sb.AppendLine($"{indent}{name}:");
+        sb.AppendLine($"{indent}  frames:");
+        foreach (var frame in anim.Frames)
+        {
+            sb.AppendLine($"{indent}    - fTimeIndex: {F(frame.TimeIndex)}");
+            sb.AppendLine($"{indent}      fValue: {F(frame.Value)}");
+        }
+    }
+
+    private static void WriteVec3(StringBuilder sb, string name, Vec3 vec, string indent)
+    {
+        sb.AppendLine($"{indent}{name}:");
+        sb.AppendLine($"{indent}  x: {F(vec.X)}");
+        sb.AppendLine($"{indent}  y: {F(vec.Y)}");
+        sb.AppendLine($"{indent}  z: {F(vec.Z)}");
+    }
+
+    private static void WriteVec2(StringBuilder sb, string name, Vec2 vec, string indent)
+    {
+        sb.AppendLine($"{indent}{name}:");
+        sb.AppendLine($"{indent}  x: {F(vec.X)}");
+        sb.AppendLine($"{indent}  y: {F(vec.Y)}");
+    }
+
+    private static void WriteColor4(StringBuilder sb, string name, Color4 color, string indent)
+    {
+        sb.AppendLine($"{indent}{name}:");
+        sb.AppendLine($"{indent}  m_fR: {F(color.R)}");
+        sb.AppendLine($"{indent}  m_fG: {F(color.G)}");
+        sb.AppendLine($"{indent}  m_fB: {F(color.B)}");
+        sb.AppendLine($"{indent}  m_fA: {F(color.A)}");
+    }
+
+    // Format float to avoid locale issues
+    private static string F(float value) =>
+        value.ToString("0.0###############", CultureInfo.InvariantCulture);
+
+    // Format bool as lowercase
+    private static string B(bool value) => value ? "true" : "false";
+}

--- a/Tools/Source/UsagiTools/src/Usagi.ToolCore/Particles/Vector3.cs
+++ b/Tools/Source/UsagiTools/src/Usagi.ToolCore/Particles/Vector3.cs
@@ -1,0 +1,67 @@
+// Usagi.ToolCore - Particle Editor Support
+// Simple vector types for particle properties
+
+namespace Usagi.ToolCore.Particles;
+
+/// <summary>
+/// 3D vector for particle positions, velocities, scales, etc.
+/// </summary>
+public struct Vec3
+{
+    public float X { get; set; }
+    public float Y { get; set; }
+    public float Z { get; set; }
+
+    public Vec3(float x, float y, float z)
+    {
+        X = x;
+        Y = y;
+        Z = z;
+    }
+
+    public static Vec3 Zero => new(0, 0, 0);
+    public static Vec3 One => new(1, 1, 1);
+    public static Vec3 Up => new(0, 1, 0);
+    public static Vec3 Down => new(0, -1, 0);
+}
+
+/// <summary>
+/// 2D vector for UV coordinates, particle centers, etc.
+/// </summary>
+public struct Vec2
+{
+    public float X { get; set; }
+    public float Y { get; set; }
+
+    public Vec2(float x, float y)
+    {
+        X = x;
+        Y = y;
+    }
+
+    public static Vec2 Zero => new(0, 0);
+    public static Vec2 Half => new(0.5f, 0.5f);
+}
+
+/// <summary>
+/// RGBA color for particle colors.
+/// </summary>
+public struct Color4
+{
+    public float R { get; set; }
+    public float G { get; set; }
+    public float B { get; set; }
+    public float A { get; set; }
+
+    public Color4(float r, float g, float b, float a = 1.0f)
+    {
+        R = r;
+        G = g;
+        B = b;
+        A = a;
+    }
+
+    public static Color4 White => new(1, 1, 1, 1);
+    public static Color4 Black => new(0, 0, 0, 1);
+    public static Color4 Clear => new(0, 0, 0, 0);
+}

--- a/Tools/Source/UsagiTools/tests/Usagi.ToolCore.Tests/Particles/ParticleDocumentTests.cs
+++ b/Tools/Source/UsagiTools/tests/Usagi.ToolCore.Tests/Particles/ParticleDocumentTests.cs
@@ -1,0 +1,162 @@
+// Usagi.ToolCore.Tests - Particle Document Tests
+
+using Usagi.ToolCore.Particles;
+using Xunit;
+
+namespace Usagi.ToolCore.Tests.Particles;
+
+public class ParticleDocumentTests
+{
+    [Fact]
+    public void EmitterDocument_CreateNew_HasDefaultSettings()
+    {
+        var doc = EditableEmitterDocument.CreateNew("TestEmitter");
+
+        Assert.Equal("TestEmitter", doc.Emitter.Name);
+        Assert.Single(doc.Emitter.Textures);
+        Assert.False(doc.IsDirty);
+    }
+
+    [Fact]
+    public void EmitterDocument_SetMaxParticles_MarksDirty()
+    {
+        var doc = EditableEmitterDocument.CreateNew();
+
+        doc.SetMaxParticles(256);
+
+        Assert.True(doc.IsDirty);
+        Assert.Equal(256, doc.Emitter.Emission.MaxParticles);
+    }
+
+    [Fact]
+    public void EmitterDocument_SetMaxParticles_CanUndo()
+    {
+        var doc = EditableEmitterDocument.CreateNew();
+        var original = doc.Emitter.Emission.MaxParticles;
+
+        doc.SetMaxParticles(256);
+        Assert.Equal(256, doc.Emitter.Emission.MaxParticles);
+
+        doc.History.Undo();
+        Assert.Equal(original, doc.Emitter.Emission.MaxParticles);
+    }
+
+    [Fact]
+    public void EmitterDocument_SetShape_CanUndoRedo()
+    {
+        var doc = EditableEmitterDocument.CreateNew();
+
+        doc.SetShape(EmitterShape.Sphere);
+        Assert.Equal(EmitterShape.Sphere, doc.Emitter.Shape);
+
+        doc.SetShape(EmitterShape.Cone);
+        Assert.Equal(EmitterShape.Cone, doc.Emitter.Shape);
+
+        doc.History.Undo();
+        Assert.Equal(EmitterShape.Sphere, doc.Emitter.Shape);
+
+        doc.History.Redo();
+        Assert.Equal(EmitterShape.Cone, doc.Emitter.Shape);
+    }
+
+    [Fact]
+    public void EmitterDocument_AddTexture_AddsAndCanUndo()
+    {
+        var doc = EditableEmitterDocument.CreateNew();
+        var initialCount = doc.Emitter.Textures.Count;
+
+        doc.AddTexture("particles/fire");
+
+        Assert.Equal(initialCount + 1, doc.Emitter.Textures.Count);
+        Assert.Equal("particles/fire", doc.Emitter.Textures[^1].Name);
+
+        doc.History.Undo();
+        Assert.Equal(initialCount, doc.Emitter.Textures.Count);
+    }
+
+    [Fact]
+    public void EmitterDocument_RemoveTexture_RemovesAndCanUndo()
+    {
+        var doc = EditableEmitterDocument.CreateNew();
+        doc.AddTexture("particles/smoke");
+        var count = doc.Emitter.Textures.Count;
+
+        doc.RemoveTexture(count - 1);
+
+        Assert.Equal(count - 1, doc.Emitter.Textures.Count);
+
+        doc.History.Undo();
+        Assert.Equal(count, doc.Emitter.Textures.Count);
+        Assert.Equal("particles/smoke", doc.Emitter.Textures[^1].Name);
+    }
+
+    [Fact]
+    public void EffectDocument_CreateNew_HasSingleEmitter()
+    {
+        var doc = EditableEffectDocument.CreateNew("TestEffect", "test_emitter");
+
+        Assert.Equal("TestEffect", doc.Effect.Name);
+        Assert.Single(doc.Effect.Emitters);
+        Assert.Equal("test_emitter", doc.Effect.Emitters[0].EmitterName);
+    }
+
+    [Fact]
+    public void EffectDocument_AddEmitter_AddsAndMarksDirty()
+    {
+        var doc = EditableEffectDocument.CreateNew("TestEffect", "emitter1");
+
+        var instance = doc.AddEmitter("emitter2");
+
+        Assert.True(doc.IsDirty);
+        Assert.Equal(2, doc.Effect.Emitters.Count);
+        Assert.Equal("emitter2", instance.EmitterName);
+    }
+
+    [Fact]
+    public void EffectDocument_RemoveEmitter_RemovesAndCanUndo()
+    {
+        var doc = EditableEffectDocument.CreateNew("TestEffect", "emitter1");
+        doc.AddEmitter("emitter2");
+        var instance = doc.Effect.Emitters[1];
+
+        doc.RemoveEmitter(instance);
+
+        Assert.Single(doc.Effect.Emitters);
+
+        doc.History.Undo();
+        Assert.Equal(2, doc.Effect.Emitters.Count);
+    }
+
+    [Fact]
+    public void EffectDocument_SetEmitterPosition_CanUndo()
+    {
+        var doc = EditableEffectDocument.CreateNew("TestEffect", "emitter1");
+        var instance = doc.Effect.Emitters[0];
+        var original = instance.Position;
+
+        var newPos = new Vec3(1, 2, 3);
+        doc.SetEmitterPosition(instance, newPos);
+
+        Assert.Equal(1.0f, instance.Position.X);
+        Assert.Equal(2.0f, instance.Position.Y);
+        Assert.Equal(3.0f, instance.Position.Z);
+
+        doc.History.Undo();
+        Assert.Equal(original.X, instance.Position.X);
+        Assert.Equal(original.Y, instance.Position.Y);
+        Assert.Equal(original.Z, instance.Position.Z);
+    }
+
+    [Fact]
+    public void EffectDocument_SetPreloadCount_CanUndo()
+    {
+        var doc = EditableEffectDocument.CreateNew("TestEffect", "emitter1");
+        var original = doc.Effect.PreloadCount;
+
+        doc.SetPreloadCount(5);
+        Assert.Equal(5, doc.Effect.PreloadCount);
+
+        doc.History.Undo();
+        Assert.Equal(original, doc.Effect.PreloadCount);
+    }
+}

--- a/Tools/Source/UsagiTools/tests/Usagi.ToolCore.Tests/Particles/ParticleParserTests.cs
+++ b/Tools/Source/UsagiTools/tests/Usagi.ToolCore.Tests/Particles/ParticleParserTests.cs
@@ -1,0 +1,406 @@
+// Usagi.ToolCore.Tests - Particle Parser Tests
+
+using System.Globalization;
+using Usagi.ToolCore.Particles;
+using Xunit;
+
+namespace Usagi.ToolCore.Tests.Particles;
+
+public class ParticleParserTests
+{
+    private const string SampleEmitterYaml = """
+        Particles.EmitterEmission:
+          blend:
+            rgbSrcFunc: 6
+            rgbDestFunc: 7
+            rgbOp: 0
+            alphaSrcFunc: 1
+            alphaDestFunc: 7
+            alphaOp: 0
+            constColor:
+              m_fR: 0.0
+              m_fG: 0.0
+              m_fB: 0.0
+              m_fA: 0.0
+            alphaTestFunc: 1
+            alphaTestReference: 0.0
+          fSoftFadeDistance: 0.5
+          sortSettings:
+            eRenderLayer: 1
+            uPriority: 5
+            bWriteDepth: false
+          textureData:
+            - name: particles/spark
+              uPatternRepeatHor: 2
+              uPatternRepeatVer: 2
+              textureAnim:
+                eTexMode: 2
+                bRandomOffset: true
+                animIndex: [0, 1, 2, 3]
+                fAnimTimeScale: 0.2
+          emission:
+            eEmissionType: 1
+            fEmissionTime: 3.0
+            emissionRate:
+              frames:
+                - fTimeIndex: 0.0
+                  fValue: 25.0
+            fReleaseInterval: 0.0
+            fReleaseIntervalRandom: 0.0
+            uMaxParticles: 64
+            vUserRotation:
+              x: 0.0
+              y: 0.0
+              z: 0.0
+          fPositionRandomness: 0.1
+          omniVelocity:
+            frames:
+              - fTimeIndex: 0.0
+                fValue: 0.5
+          dirVelocity:
+            frames:
+              - fTimeIndex: 0.0
+                fValue: 1.0
+          vVelocityDir:
+            x: 0.0
+            y: 1.0
+            z: 0.0
+          fVelocityDirConeDeg: 30.0
+          fSpeedRandomness: 0.2
+          bInheritVelocity: false
+          bLocalEffect: true
+          bCPUPositionUpdate: false
+          fDrag: 0.05
+          fGravityStrength: 0.5
+          vGravityDir:
+            x: 0.0
+            y: -1.0
+            z: 0.0
+          eParticleType: 0
+          life:
+            frames:
+              - fTimeIndex: 0.0
+                fValue: 2.0
+          fLifeRandomness: 0.3
+          vParticleCenter:
+            x: 0.5
+            y: 0.5
+          particleColor:
+            eColorMode: 0
+            cColor0:
+              m_fR: 1.0
+              m_fG: 0.8
+              m_fB: 0.2
+              m_fA: 1.0
+            cColor1:
+              m_fR: 1.0
+              m_fG: 0.5
+              m_fB: 0.1
+              m_fA: 1.0
+            cColor2:
+              m_fR: 1.0
+              m_fG: 1.0
+              m_fB: 1.0
+              m_fA: 1.0
+            fInTimeEnd: 0.0
+            fOutTimeStart: 1.0
+            fPeak: 1.0
+            uRepetitionCount: 0
+            bRandomRepetitionPos: false
+            fLerpEnvColor: 0.0
+          particleAlpha:
+            fInitialAlpha: 0.0
+            fIntermediateAlpha: 1.0
+            fEndAlpha: 0.0
+            fFinishInTime: 0.1
+            fOutStartTiming: 0.8
+          particleRotation:
+            fBaseRotation: 0.0
+            fRandomise: 360.0
+            fSpeed: 45.0
+            fSpeedRandomise: 20.0
+          particleScale:
+            standardValue:
+              frames:
+                - fTimeIndex: 0.0
+                  fValue: 0.5
+            fRandomness: 0.2
+            fInitial: 0.5
+            fIntermediate: 1.0
+            fEnding: 0.2
+            fBeginScaleIn: 0.1
+            fStartScaleOut: 0.7
+          eShape: 1
+        ---
+        Particles.EmitterShapeDetails:
+          baseShape:
+            vScale:
+              x: 1.0
+              y: 1.0
+              z: 1.0
+            vRotation:
+              x: 0.0
+              y: 0.0
+              z: 0.0
+            vPosition:
+              x: 0.0
+              y: 0.0
+              z: 0.0
+            fHollowness: 0.5
+            vVelocity:
+              x: 0.0
+              y: 0.0
+              z: 0.0
+            fSpeedRand: 0.0
+            vGravity:
+              x: 0.0
+              y: 0.0
+              z: 0.0
+            fShapeExpandVel: 0.0
+          arc:
+            fArcWidthDeg: 360.0
+            fArcStartDeg: 0.0
+            bRandomizeStartAngle: false
+          vShapeExtents:
+            x: 0.0
+            y: 0.0
+            z: 0.0
+        """;
+
+    private const string SampleEffectYaml = """
+        Particles.EffectGroup:
+          emitters:
+            - emitterName: spark_burst
+              vScale:
+                x: 1.0
+                y: 1.0
+                z: 1.0
+              vRotation:
+                x: 0.0
+                y: 0.0
+                z: 0.0
+              vPosition:
+                x: 0.0
+                y: 0.5
+                z: 0.0
+              fParticleScale: 1.5
+              fReleaseFrame: 0.0
+            - emitterName: smoke_trail
+              vScale:
+                x: 2.0
+                y: 2.0
+                z: 2.0
+              vRotation:
+                x: 0.0
+                y: 45.0
+                z: 0.0
+              vPosition:
+                x: 0.0
+                y: 0.0
+                z: 0.0
+              fParticleScale: 1.0
+              fReleaseFrame: 0.5
+          uPreloadCount: 2
+        """;
+
+    [Fact]
+    public void ParseEmitter_ParsesBasicProperties()
+    {
+        var emitter = ParticleYamlParser.ParseEmitterFromYaml(SampleEmitterYaml);
+
+        Assert.Equal(0.5f, emitter.SoftFadeDistance);
+        Assert.Equal(EmitterShape.Sphere, emitter.Shape);
+        Assert.Equal(ParticleType.Billboard, emitter.Type);
+        Assert.True(emitter.LocalEffect);
+    }
+
+    [Fact]
+    public void ParseEmitter_ParsesBlendSettings()
+    {
+        var emitter = ParticleYamlParser.ParseEmitterFromYaml(SampleEmitterYaml);
+
+        Assert.Equal(BlendFunc.SrcAlpha, emitter.Blend.RgbSrcFunc);
+        Assert.Equal(BlendFunc.OneMinusSrcAlpha, emitter.Blend.RgbDestFunc);
+        Assert.Equal(BlendOp.Add, emitter.Blend.RgbOp);
+    }
+
+    [Fact]
+    public void ParseEmitter_ParsesSortSettings()
+    {
+        var emitter = ParticleYamlParser.ParseEmitterFromYaml(SampleEmitterYaml);
+
+        Assert.Equal(1, emitter.Sort.RenderLayer);
+        Assert.Equal(5, emitter.Sort.Priority);
+        Assert.False(emitter.Sort.WriteDepth);
+    }
+
+    [Fact]
+    public void ParseEmitter_ParsesTextures()
+    {
+        var emitter = ParticleYamlParser.ParseEmitterFromYaml(SampleEmitterYaml);
+
+        Assert.Single(emitter.Textures);
+        Assert.Equal("particles/spark", emitter.Textures[0].Name);
+        Assert.Equal(2, emitter.Textures[0].PatternRepeatHor);
+        Assert.Equal(TextureAnimMode.Random, emitter.Textures[0].Animation.Mode);
+        Assert.True(emitter.Textures[0].Animation.RandomOffset);
+        Assert.Equal([0, 1, 2, 3], emitter.Textures[0].Animation.AnimIndex);
+    }
+
+    [Fact]
+    public void ParseEmitter_UsesInvariantFloatFormatting()
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        var originalUiCulture = CultureInfo.CurrentUICulture;
+
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("fr-FR");
+
+            var emitter = ParticleYamlParser.ParseEmitterFromYaml(SampleEmitterYaml);
+
+            Assert.Equal(0.5f, emitter.SoftFadeDistance);
+            Assert.Equal(0.2f, emitter.Textures[0].Animation.AnimTimeScale);
+            Assert.Equal(25.0f, emitter.Emission.EmissionRate.Frames[0].Value);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+            CultureInfo.CurrentUICulture = originalUiCulture;
+        }
+    }
+
+    [Fact]
+    public void WriteEmitter_PreservesMultipleTextureSlots()
+    {
+        var emitter = ParticleYamlParser.ParseEmitterFromYaml(SampleEmitterYaml);
+        emitter.Textures.Add(new TextureSlot
+        {
+            Name = "particles/spark_overlay",
+            PatternRepeatHor = 4,
+            PatternRepeatVer = 1
+        });
+        emitter.Textures[1].Animation.Mode = TextureAnimMode.Linear;
+        emitter.Textures[1].Animation.AnimIndex.AddRange([3, 2, 1, 0]);
+        emitter.Textures[1].Animation.AnimTimeScale = 0.11f;
+
+        var yaml = ParticleYamlWriter.WriteEmitter(emitter);
+        var roundTripped = ParticleYamlParser.ParseEmitterFromYaml(yaml);
+
+        Assert.Equal(2, roundTripped.Textures.Count);
+        Assert.Equal("particles/spark", roundTripped.Textures[0].Name);
+        Assert.Equal("particles/spark_overlay", roundTripped.Textures[1].Name);
+        Assert.Equal(4, roundTripped.Textures[1].PatternRepeatHor);
+        Assert.Equal(TextureAnimMode.Linear, roundTripped.Textures[1].Animation.Mode);
+        Assert.Equal([3, 2, 1, 0], roundTripped.Textures[1].Animation.AnimIndex);
+        Assert.Equal(0.11f, roundTripped.Textures[1].Animation.AnimTimeScale);
+    }
+
+    [Fact]
+    public void ParseEmitter_ParsesEmission()
+    {
+        var emitter = ParticleYamlParser.ParseEmitterFromYaml(SampleEmitterYaml);
+
+        Assert.Equal(EmissionType.OneShot, emitter.Emission.Type);
+        Assert.Equal(3.0f, emitter.Emission.EmissionTime);
+        Assert.Equal(64, emitter.Emission.MaxParticles);
+        Assert.Single(emitter.Emission.EmissionRate.Frames);
+        Assert.Equal(25.0f, emitter.Emission.EmissionRate.Frames[0].Value);
+    }
+
+    [Fact]
+    public void ParseEmitter_ParsesVelocity()
+    {
+        var emitter = ParticleYamlParser.ParseEmitterFromYaml(SampleEmitterYaml);
+
+        Assert.Equal(0.5f, emitter.OmniVelocity.Frames[0].Value);
+        Assert.Equal(1.0f, emitter.DirVelocity.Frames[0].Value);
+        Assert.Equal(0.0f, emitter.VelocityDir.X);
+        Assert.Equal(1.0f, emitter.VelocityDir.Y);
+        Assert.Equal(30.0f, emitter.VelocityDirConeDeg);
+    }
+
+    [Fact]
+    public void ParseEmitter_ParsesLife()
+    {
+        var emitter = ParticleYamlParser.ParseEmitterFromYaml(SampleEmitterYaml);
+
+        Assert.Single(emitter.Life.Frames);
+        Assert.Equal(2.0f, emitter.Life.Frames[0].Value);
+        Assert.Equal(0.3f, emitter.LifeRandomness);
+    }
+
+    [Fact]
+    public void ParseEmitter_ParsesColor()
+    {
+        var emitter = ParticleYamlParser.ParseEmitterFromYaml(SampleEmitterYaml);
+
+        Assert.Equal(ColorMode.Constant, emitter.Color.Mode);
+        Assert.Equal(1.0f, emitter.Color.Color0.R);
+        Assert.Equal(0.8f, emitter.Color.Color0.G);
+        Assert.Equal(0.2f, emitter.Color.Color0.B);
+    }
+
+    [Fact]
+    public void ParseEmitter_ParsesShapeDetails()
+    {
+        var emitter = ParticleYamlParser.ParseEmitterFromYaml(SampleEmitterYaml);
+
+        Assert.Equal(0.5f, emitter.ShapeDetails.BaseShape.Hollowness);
+        Assert.Equal(360.0f, emitter.ShapeDetails.Arc.ArcWidthDeg);
+    }
+
+    [Fact]
+    public void ParseEffect_ParsesBasicProperties()
+    {
+        var effect = ParticleYamlParser.ParseEffectFromYaml(SampleEffectYaml);
+
+        Assert.Equal(2, effect.PreloadCount);
+    }
+
+    [Fact]
+    public void ParseEffect_ParsesEmitters()
+    {
+        var effect = ParticleYamlParser.ParseEffectFromYaml(SampleEffectYaml);
+
+        Assert.Equal(2, effect.Emitters.Count);
+
+        Assert.Equal("spark_burst", effect.Emitters[0].EmitterName);
+        Assert.Equal(0.5f, effect.Emitters[0].Position.Y);
+        Assert.Equal(1.5f, effect.Emitters[0].ParticleScale);
+
+        Assert.Equal("smoke_trail", effect.Emitters[1].EmitterName);
+        Assert.Equal(2.0f, effect.Emitters[1].Scale.X);
+        Assert.Equal(45.0f, effect.Emitters[1].Rotation.Y);
+        Assert.Equal(0.5f, effect.Emitters[1].ReleaseFrame);
+    }
+
+    [Fact]
+    public void WriteEmitter_RoundTrips()
+    {
+        var original = ParticleYamlParser.ParseEmitterFromYaml(SampleEmitterYaml);
+        var yaml = ParticleYamlWriter.WriteEmitter(original);
+        var roundTripped = ParticleYamlParser.ParseEmitterFromYaml(yaml);
+
+        // Verify key properties survived round-trip
+        Assert.Equal(original.SoftFadeDistance, roundTripped.SoftFadeDistance);
+        Assert.Equal(original.Shape, roundTripped.Shape);
+        Assert.Equal(original.Emission.MaxParticles, roundTripped.Emission.MaxParticles);
+        Assert.Equal(original.Life.Frames[0].Value, roundTripped.Life.Frames[0].Value);
+        Assert.Equal(original.Textures[0].Name, roundTripped.Textures[0].Name);
+    }
+
+    [Fact]
+    public void WriteEffect_RoundTrips()
+    {
+        var original = ParticleYamlParser.ParseEffectFromYaml(SampleEffectYaml);
+        var yaml = ParticleYamlWriter.WriteEffect(original);
+        var roundTripped = ParticleYamlParser.ParseEffectFromYaml(yaml);
+
+        Assert.Equal(original.PreloadCount, roundTripped.PreloadCount);
+        Assert.Equal(original.Emitters.Count, roundTripped.Emitters.Count);
+        Assert.Equal(original.Emitters[0].EmitterName, roundTripped.Emitters[0].EmitterName);
+        Assert.Equal(original.Emitters[0].ParticleScale, roundTripped.Emitters[0].ParticleScale);
+    }
+}


### PR DESCRIPTION
This adds the managed ToolCore particle document model, parser, writer, and
tests without adding UI or particle runtime changes.

Why this makes sense:

- Particle editor UI work needs a tested document layer before any Avalonia
  controls or native preview integration are reviewed.
- The model preserves prior particle tooling behavior as managed data
  structures that can be validated independently of the engine runtime.
- Keeping the branch stacked on PR 08 avoids duplicating shared ToolCore
  services and keeps this slice focused on particle data.

What changed:

- Added editable emitter/effect document types with undoable edit operations.
- Added particle YAML parser/writer support for emitter/effect files.
- Added typed particle value models, animated values, texture slots, blend/sort,
  emission, color, alpha, rotation, scale, and shape data.
- Added parser and document tests, including multi-texture data shape coverage.
- Did not add ToolShell UI, engine particle runtime changes, preview code, or
  audio/entity files.

Validation:

- `dotnet test Tools/Source/UsagiTools/UsagiTools.slnx` passed, 70 tests.
- `git diff --check`