### PR TITLE
Add native preview host scaffold

### DIFF
--- a/Documents/PreviewHost.md
+++ b/Documents/PreviewHost.md
@@ -1,0 +1,71 @@
+# Usagi Preview Host
+
+## Purpose
+
+`UsagiPreviewHost.exe` is the native process that future Avalonia tools will use for embedded engine previews. The first checked-in version is intentionally a small Win32 scaffold, not an engine renderer. It establishes the process boundary, window-hosting contract, and JSON-lines IPC shape while leaving scene and particle rendering behind explicit TODO responses.
+
+## Existing Pattern Survey
+
+ParticleEditor hosts a native Win32 window in `Tools/Source/ParticleEditor/main/_win/WinMain.cpp`, registers that window with `Input::GetPlatform().RegisterHwnd`, then enters `GameMain`. The tool implementation is a `GameInterface` subclass in `ParticleEditor.cpp`.
+
+The shared engine loop in `Engine/Game/GameMain.cpp` creates the game object through `CreateGame`, calls `PreGFXInit`, initializes the graphics display from `WINUTIL::GetWindow`, and drives `Update` and `Draw` while `GameInterface::IsRunning` remains true.
+
+The historical Avalonia tool shell branches have a protocol/client shape under `Tools/Source/UsagiTools/src/Usagi.ToolCore/Preview`: they start `Tools/bin/UsagiPreviewHost.exe`, redirect stdin/stdout, send newline-delimited JSON commands, and wait for a `ready` response. This branch keeps that contract documented without adding managed `UsagiTools` projects.
+
+## Current Scaffold
+
+The current native host lives in `Tools/Source/UsagiPreviewHost` and builds from `project/UsagiPreviewHost.vcxproj` as a standalone x64 Win32 executable.
+
+Implemented:
+
+- Hidden Win32 preview window creation.
+- Non-blocking polling of redirected stdin pipes.
+- JSON-lines command parsing for protocol version 1.
+- JSON responses compatible with `PreviewProtocol.cs`.
+- `init` protocol validation and `ready` response.
+- `attachWindow` reparenting of the native host window into the supplied parent HWND.
+- Commands other than `init` and `shutdown` are rejected until protocol negotiation succeeds.
+- Stubbed `loadEntity`, `loadParticle`, `tick`, `pick`, and camera command handling.
+- Graceful shutdown on `shutdown` or window close.
+- `Tools/Tests/PreviewHost/Run.ps1` build/headless smoke coverage for protocol startup, stub responses, picking, and shutdown.
+
+Not implemented:
+
+- Engine `GameMain` integration.
+- Graphics device creation against the Avalonia-hosted child window.
+- Entity or particle resource loading.
+- Camera state storage beyond accepting the command.
+- Picking.
+
+## Protocol
+
+Commands are UTF-8 compatible JSON objects delimited by `\n`. The first command should be:
+
+```json
+{"type":"init","protocolVersion":1,"dataPath":"...","romfilesPath":"..."}
+```
+
+The host responds:
+
+```json
+{"type":"ready","protocolVersion":1,"engineVersion":"UsagiPreviewHost scaffold"}
+```
+
+After the Avalonia surface has a native handle, the client sends:
+
+```json
+{"type":"attachWindow","hwnd":123456,"width":800,"height":600}
+```
+
+The scaffold validates the HWND, calls `SetParent`, switches its window to `WS_CHILD | WS_VISIBLE`, resizes it, and emits a diagnostic response.
+
+## Next Engine Step
+
+The next slice should decide how to bridge the ParticleEditor/GameInterface pattern with an externally owned child window. The likely path is:
+
+1. Extend or wrap the Win32 entry point so `WINUTIL::SetWindow` points at the attached child window before `GFX::Initialise` initializes the display.
+2. Move the current IPC loop into a lightweight `GameInterface` implementation that processes commands in `Update`.
+3. Add a minimal render path that clears the hosted window before loading entities or particles.
+4. Only then wire `loadParticle` to the same particle systems used by ParticleEditor.
+
+Keeping the first scaffold standalone avoids taking on renderer lifetime, OpenGL/Vulkan context ownership, and engine reset behavior before the Avalonia embedding contract is proven.

--- a/Tools/Source/UsagiPreviewHost/IpcProtocol.cpp
+++ b/Tools/Source/UsagiPreviewHost/IpcProtocol.cpp
@@ -1,0 +1,382 @@
+/****************************************************************************
+//  Usagi preview host IPC protocol implementation.
+****************************************************************************/
+#include "IpcProtocol.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+static const char* SkipWhitespace(const char* p)
+{
+    while (*p == ' ' || *p == '\t' || *p == '\r' || *p == '\n')
+    {
+        ++p;
+    }
+
+    return p;
+}
+
+static const char* FindKey(const char* json, const char* key)
+{
+    char pattern[128];
+    std::snprintf(pattern, sizeof(pattern), "\"%s\"", key);
+
+    const char* found = std::strstr(json, pattern);
+    if (found == nullptr)
+    {
+        return nullptr;
+    }
+
+    found += std::strlen(pattern);
+    found = SkipWhitespace(found);
+    if (*found != ':')
+    {
+        return nullptr;
+    }
+
+    return SkipWhitespace(found + 1);
+}
+
+const char* IpcParser::FindString(const char* json, const char* key, char* buffer, int bufferSize)
+{
+    if (bufferSize <= 0)
+    {
+        return nullptr;
+    }
+
+    const char* value = FindKey(json, key);
+    if (value == nullptr)
+    {
+        return nullptr;
+    }
+
+    if (std::strncmp(value, "null", 4) == 0)
+    {
+        buffer[0] = '\0';
+        return buffer;
+    }
+
+    if (*value != '"')
+    {
+        return nullptr;
+    }
+
+    ++value;
+
+    int i = 0;
+    while (*value != '\0' && *value != '"' && i < bufferSize - 1)
+    {
+        if (*value == '\\' && value[1] != '\0')
+        {
+            ++value;
+            switch (*value)
+            {
+            case 'n':
+                buffer[i++] = '\n';
+                break;
+            case 'r':
+                buffer[i++] = '\r';
+                break;
+            case 't':
+                buffer[i++] = '\t';
+                break;
+            case '"':
+            case '\\':
+                buffer[i++] = *value;
+                break;
+            default:
+                buffer[i++] = *value;
+                break;
+            }
+        }
+        else
+        {
+            buffer[i++] = *value;
+        }
+
+        ++value;
+    }
+
+    buffer[i] = '\0';
+    return buffer;
+}
+
+bool IpcParser::FindInt(const char* json, const char* key, int& out)
+{
+    const char* value = FindKey(json, key);
+    if (value == nullptr)
+    {
+        return false;
+    }
+
+    char* end = nullptr;
+    const long result = std::strtol(value, &end, 10);
+    if (end == value)
+    {
+        return false;
+    }
+
+    out = static_cast<int>(result);
+    return true;
+}
+
+bool IpcParser::FindInt64(const char* json, const char* key, int64_t& out)
+{
+    const char* value = FindKey(json, key);
+    if (value == nullptr)
+    {
+        return false;
+    }
+
+    char* end = nullptr;
+    const long long result = _strtoi64(value, &end, 10);
+    if (end == value)
+    {
+        return false;
+    }
+
+    out = static_cast<int64_t>(result);
+    return true;
+}
+
+bool IpcParser::FindFloat(const char* json, const char* key, float& out)
+{
+    const char* value = FindKey(json, key);
+    if (value == nullptr)
+    {
+        return false;
+    }
+
+    char* end = nullptr;
+    const float result = std::strtof(value, &end);
+    if (end == value)
+    {
+        return false;
+    }
+
+    out = result;
+    return true;
+}
+
+IpcCommandType IpcParser::ParseCommandType(const char* json)
+{
+    char type[64];
+    if (FindString(json, "type", type, sizeof(type)) == nullptr)
+    {
+        return IpcCommandType::Unknown;
+    }
+
+    if (std::strcmp(type, "init") == 0) return IpcCommandType::Init;
+    if (std::strcmp(type, "shutdown") == 0) return IpcCommandType::Shutdown;
+    if (std::strcmp(type, "attachWindow") == 0) return IpcCommandType::AttachWindow;
+    if (std::strcmp(type, "loadEntity") == 0) return IpcCommandType::LoadEntity;
+    if (std::strcmp(type, "loadParticle") == 0) return IpcCommandType::LoadParticle;
+    if (std::strcmp(type, "tick") == 0) return IpcCommandType::Tick;
+    if (std::strcmp(type, "pick") == 0) return IpcCommandType::Pick;
+    if (std::strcmp(type, "setCameraPosition") == 0) return IpcCommandType::SetCameraPosition;
+
+    return IpcCommandType::Unknown;
+}
+
+bool IpcParser::ParseInit(const char* json, IpcInitCommand& out)
+{
+    std::memset(&out, 0, sizeof(out));
+    if (!FindInt(json, "protocolVersion", out.protocolVersion))
+    {
+        return false;
+    }
+
+    FindString(json, "dataPath", out.dataPath, sizeof(out.dataPath));
+    FindString(json, "romfilesPath", out.romfilesPath, sizeof(out.romfilesPath));
+    return true;
+}
+
+bool IpcParser::ParseAttachWindow(const char* json, IpcAttachWindowCommand& out)
+{
+    std::memset(&out, 0, sizeof(out));
+    if (!FindInt64(json, "hwnd", out.hwnd)) return false;
+    if (!FindInt(json, "width", out.width)) out.width = 1;
+    if (!FindInt(json, "height", out.height)) out.height = 1;
+    return true;
+}
+
+bool IpcParser::ParseLoadEntity(const char* json, IpcLoadEntityCommand& out)
+{
+    std::memset(&out, 0, sizeof(out));
+    return FindString(json, "path", out.path, sizeof(out.path)) != nullptr;
+}
+
+bool IpcParser::ParseLoadParticle(const char* json, IpcLoadParticleCommand& out)
+{
+    std::memset(&out, 0, sizeof(out));
+    if (FindString(json, "emitterPath", out.emitterPath, sizeof(out.emitterPath)) == nullptr)
+    {
+        return false;
+    }
+
+    FindString(json, "effectPath", out.effectPath, sizeof(out.effectPath));
+    return true;
+}
+
+bool IpcParser::ParseTick(const char* json, IpcTickCommand& out)
+{
+    std::memset(&out, 0, sizeof(out));
+    out.deltaTime = 1.0f / 60.0f;
+    FindFloat(json, "deltaTime", out.deltaTime);
+    return true;
+}
+
+bool IpcParser::ParsePick(const char* json, IpcPickCommand& out)
+{
+    std::memset(&out, 0, sizeof(out));
+    return FindInt(json, "x", out.x) && FindInt(json, "y", out.y);
+}
+
+bool IpcParser::ParseSetCameraPosition(const char* json, IpcSetCameraPositionCommand& out)
+{
+    std::memset(&out, 0, sizeof(out));
+    return FindFloat(json, "x", out.x)
+        && FindFloat(json, "y", out.y)
+        && FindFloat(json, "z", out.z)
+        && FindFloat(json, "targetX", out.targetX)
+        && FindFloat(json, "targetY", out.targetY)
+        && FindFloat(json, "targetZ", out.targetZ);
+}
+
+static void EscapeJsonString(const char* input, char* output, int outputSize)
+{
+    int j = 0;
+    const char* safeInput = input != nullptr ? input : "";
+
+    for (int i = 0; safeInput[i] != '\0' && j < outputSize - 1; ++i)
+    {
+        const char c = safeInput[i];
+        const char* replacement = nullptr;
+        char escaped[3] = {};
+
+        switch (c)
+        {
+        case '"': replacement = "\\\""; break;
+        case '\\': replacement = "\\\\"; break;
+        case '\n': replacement = "\\n"; break;
+        case '\r': replacement = "\\r"; break;
+        case '\t': replacement = "\\t"; break;
+        default:
+            escaped[0] = c;
+            replacement = escaped;
+            break;
+        }
+
+        for (int k = 0; replacement[k] != '\0' && j < outputSize - 1; ++k)
+        {
+            output[j++] = replacement[k];
+        }
+    }
+
+    output[j] = '\0';
+}
+
+void IpcResponse::Ready(char* buffer, int bufferSize, int protocolVersion, const char* engineVersion)
+{
+    char escapedVersion[128];
+    EscapeJsonString(engineVersion, escapedVersion, sizeof(escapedVersion));
+
+    std::snprintf(buffer, bufferSize,
+        "{\"type\":\"ready\",\"protocolVersion\":%d,\"engineVersion\":\"%s\"}",
+        protocolVersion, escapedVersion);
+}
+
+void IpcResponse::Error(char* buffer, int bufferSize, const char* message, const char* details)
+{
+    char escapedMessage[512];
+    EscapeJsonString(message, escapedMessage, sizeof(escapedMessage));
+
+    if (details != nullptr)
+    {
+        char escapedDetails[512];
+        EscapeJsonString(details, escapedDetails, sizeof(escapedDetails));
+        std::snprintf(buffer, bufferSize,
+            "{\"type\":\"error\",\"message\":\"%s\",\"details\":\"%s\"}",
+            escapedMessage, escapedDetails);
+    }
+    else
+    {
+        std::snprintf(buffer, bufferSize,
+            "{\"type\":\"error\",\"message\":\"%s\"}",
+            escapedMessage);
+    }
+}
+
+void IpcResponse::Loaded(char* buffer, int bufferSize, const char* resourceType, const char* path, bool success, const char* error)
+{
+    char escapedType[64];
+    char escapedPath[IPC_MAX_PATH];
+    EscapeJsonString(resourceType, escapedType, sizeof(escapedType));
+    EscapeJsonString(path, escapedPath, sizeof(escapedPath));
+
+    if (error != nullptr)
+    {
+        char escapedError[512];
+        EscapeJsonString(error, escapedError, sizeof(escapedError));
+        std::snprintf(buffer, bufferSize,
+            "{\"type\":\"loaded\",\"resourceType\":\"%s\",\"path\":\"%s\",\"success\":%s,\"error\":\"%s\"}",
+            escapedType, escapedPath, success ? "true" : "false", escapedError);
+    }
+    else
+    {
+        std::snprintf(buffer, bufferSize,
+            "{\"type\":\"loaded\",\"resourceType\":\"%s\",\"path\":\"%s\",\"success\":%s}",
+            escapedType, escapedPath, success ? "true" : "false");
+    }
+}
+
+void IpcResponse::Picked(char* buffer, int bufferSize, const char* entityId, const char* componentName)
+{
+    if (entityId == nullptr)
+    {
+        std::snprintf(buffer, bufferSize, "{\"type\":\"picked\",\"entityId\":null}");
+        return;
+    }
+
+    char escapedId[256];
+    EscapeJsonString(entityId, escapedId, sizeof(escapedId));
+
+    if (componentName != nullptr)
+    {
+        char escapedComponent[256];
+        EscapeJsonString(componentName, escapedComponent, sizeof(escapedComponent));
+        std::snprintf(buffer, bufferSize,
+            "{\"type\":\"picked\",\"entityId\":\"%s\",\"componentName\":\"%s\"}",
+            escapedId, escapedComponent);
+    }
+    else
+    {
+        std::snprintf(buffer, bufferSize,
+            "{\"type\":\"picked\",\"entityId\":\"%s\",\"componentName\":null}",
+            escapedId);
+    }
+}
+
+void IpcResponse::Diagnostic(char* buffer, int bufferSize, const char* level, const char* message, const char* source)
+{
+    char escapedLevel[32];
+    char escapedMessage[1024];
+    EscapeJsonString(level, escapedLevel, sizeof(escapedLevel));
+    EscapeJsonString(message, escapedMessage, sizeof(escapedMessage));
+
+    if (source != nullptr)
+    {
+        char escapedSource[256];
+        EscapeJsonString(source, escapedSource, sizeof(escapedSource));
+        std::snprintf(buffer, bufferSize,
+            "{\"type\":\"diagnostic\",\"level\":\"%s\",\"message\":\"%s\",\"source\":\"%s\"}",
+            escapedLevel, escapedMessage, escapedSource);
+    }
+    else
+    {
+        std::snprintf(buffer, bufferSize,
+            "{\"type\":\"diagnostic\",\"level\":\"%s\",\"message\":\"%s\"}",
+            escapedLevel, escapedMessage);
+    }
+}

--- a/Tools/Source/UsagiPreviewHost/IpcProtocol.h
+++ b/Tools/Source/UsagiPreviewHost/IpcProtocol.h
@@ -1,0 +1,103 @@
+/****************************************************************************
+//  Usagi preview host IPC protocol.
+//  JSON-lines messages shared with Usagi.ToolCore.Preview.
+****************************************************************************/
+#pragma once
+
+#ifndef USAGI_PREVIEW_HOST_IPC_PROTOCOL_H
+#define USAGI_PREVIEW_HOST_IPC_PROTOCOL_H
+
+#include <cstdint>
+
+static constexpr int IPC_PROTOCOL_VERSION = 1;
+static constexpr int IPC_MAX_PATH = 512;
+
+enum class IpcCommandType
+{
+    Unknown,
+    Init,
+    Shutdown,
+    AttachWindow,
+    LoadEntity,
+    LoadParticle,
+    Tick,
+    Pick,
+    SetCameraPosition
+};
+
+struct IpcInitCommand
+{
+    int protocolVersion;
+    char dataPath[IPC_MAX_PATH];
+    char romfilesPath[IPC_MAX_PATH];
+};
+
+struct IpcAttachWindowCommand
+{
+    int64_t hwnd;
+    int width;
+    int height;
+};
+
+struct IpcLoadEntityCommand
+{
+    char path[IPC_MAX_PATH];
+};
+
+struct IpcLoadParticleCommand
+{
+    char emitterPath[IPC_MAX_PATH];
+    char effectPath[IPC_MAX_PATH];
+};
+
+struct IpcTickCommand
+{
+    float deltaTime;
+};
+
+struct IpcPickCommand
+{
+    int x;
+    int y;
+};
+
+struct IpcSetCameraPositionCommand
+{
+    float x;
+    float y;
+    float z;
+    float targetX;
+    float targetY;
+    float targetZ;
+};
+
+class IpcParser
+{
+public:
+    static IpcCommandType ParseCommandType(const char* json);
+    static bool ParseInit(const char* json, IpcInitCommand& out);
+    static bool ParseAttachWindow(const char* json, IpcAttachWindowCommand& out);
+    static bool ParseLoadEntity(const char* json, IpcLoadEntityCommand& out);
+    static bool ParseLoadParticle(const char* json, IpcLoadParticleCommand& out);
+    static bool ParseTick(const char* json, IpcTickCommand& out);
+    static bool ParsePick(const char* json, IpcPickCommand& out);
+    static bool ParseSetCameraPosition(const char* json, IpcSetCameraPositionCommand& out);
+
+private:
+    static const char* FindString(const char* json, const char* key, char* buffer, int bufferSize);
+    static bool FindInt(const char* json, const char* key, int& out);
+    static bool FindInt64(const char* json, const char* key, int64_t& out);
+    static bool FindFloat(const char* json, const char* key, float& out);
+};
+
+class IpcResponse
+{
+public:
+    static void Ready(char* buffer, int bufferSize, int protocolVersion, const char* engineVersion);
+    static void Error(char* buffer, int bufferSize, const char* message, const char* details = nullptr);
+    static void Loaded(char* buffer, int bufferSize, const char* resourceType, const char* path, bool success, const char* error = nullptr);
+    static void Picked(char* buffer, int bufferSize, const char* entityId, const char* componentName);
+    static void Diagnostic(char* buffer, int bufferSize, const char* level, const char* message, const char* source = nullptr);
+};
+
+#endif

--- a/Tools/Source/UsagiPreviewHost/PreviewHost.cpp
+++ b/Tools/Source/UsagiPreviewHost/PreviewHost.cpp
@@ -1,0 +1,434 @@
+/****************************************************************************
+//  Minimal native preview host for Avalonia tools.
+****************************************************************************/
+#include "PreviewHost.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+
+static const char* kWindowClassName = "UsagiPreviewHostWindow";
+static const char* kEngineVersion = "UsagiPreviewHost scaffold";
+
+PreviewHost::PreviewHost()
+    : m_hwnd(nullptr)
+    , m_parentHwnd(nullptr)
+    , m_stdin(GetStdHandle(STD_INPUT_HANDLE))
+    , m_stdout(GetStdHandle(STD_OUTPUT_HANDLE))
+    , m_stdinType(FILE_TYPE_UNKNOWN)
+    , m_shutdownRequested(false)
+    , m_protocolReady(false)
+    , m_inputPos(0)
+{
+    std::memset(m_inputBuffer, 0, sizeof(m_inputBuffer));
+    if (m_stdin != INVALID_HANDLE_VALUE && m_stdin != nullptr)
+    {
+        m_stdinType = GetFileType(m_stdin);
+    }
+}
+
+PreviewHost::~PreviewHost()
+{
+    if (m_hwnd != nullptr)
+    {
+        DestroyWindow(m_hwnd);
+        m_hwnd = nullptr;
+    }
+}
+
+int PreviewHost::Run(HINSTANCE instance, int showCommand)
+{
+    UNREFERENCED_PARAMETER(showCommand);
+
+    if (!CreatePreviewWindow(instance))
+    {
+        SendError("Failed to create preview host window");
+        return 1;
+    }
+
+    SendDiagnostic("info", "Preview host process started");
+
+    MSG message = {};
+    while (!m_shutdownRequested)
+    {
+        while (PeekMessage(&message, nullptr, 0, 0, PM_REMOVE))
+        {
+            if (message.message == WM_QUIT)
+            {
+                m_shutdownRequested = true;
+                break;
+            }
+
+            TranslateMessage(&message);
+            DispatchMessage(&message);
+        }
+
+        PumpStdIn();
+        Sleep(8);
+    }
+
+    return 0;
+}
+
+bool PreviewHost::CreatePreviewWindow(HINSTANCE instance)
+{
+    WNDCLASSEXA windowClass = {};
+    windowClass.cbSize = sizeof(windowClass);
+    windowClass.style = CS_HREDRAW | CS_VREDRAW;
+    windowClass.lpfnWndProc = PreviewHost::WindowProc;
+    windowClass.hInstance = instance;
+    windowClass.hCursor = LoadCursor(nullptr, IDC_ARROW);
+    windowClass.lpszClassName = kWindowClassName;
+
+    const ATOM registeredClass = RegisterClassExA(&windowClass);
+    if (registeredClass == 0 && GetLastError() != ERROR_CLASS_ALREADY_EXISTS)
+    {
+        return false;
+    }
+
+    m_hwnd = CreateWindowExA(
+        0,
+        kWindowClassName,
+        "Usagi Preview Host",
+        WS_OVERLAPPEDWINDOW | WS_CLIPCHILDREN | WS_CLIPSIBLINGS,
+        CW_USEDEFAULT,
+        CW_USEDEFAULT,
+        800,
+        600,
+        nullptr,
+        nullptr,
+        instance,
+        this);
+
+    if (m_hwnd == nullptr)
+    {
+        return false;
+    }
+
+    ShowWindow(m_hwnd, SW_HIDE);
+    return true;
+}
+
+LRESULT CALLBACK PreviewHost::WindowProc(HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam)
+{
+    PreviewHost* host = reinterpret_cast<PreviewHost*>(GetWindowLongPtr(hwnd, GWLP_USERDATA));
+
+    if (message == WM_NCCREATE)
+    {
+        const CREATESTRUCT* createStruct = reinterpret_cast<const CREATESTRUCT*>(lparam);
+        host = reinterpret_cast<PreviewHost*>(createStruct->lpCreateParams);
+        SetWindowLongPtr(hwnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(host));
+    }
+
+    switch (message)
+    {
+    case WM_SIZE:
+        if (host != nullptr && wparam != SIZE_MINIMIZED)
+        {
+            host->ResizeHostedWindow(LOWORD(lparam), HIWORD(lparam));
+        }
+        break;
+
+    case WM_CLOSE:
+        if (host != nullptr)
+        {
+            host->HandleShutdown();
+            return 0;
+        }
+        break;
+
+    case WM_DESTROY:
+        PostQuitMessage(0);
+        break;
+    }
+
+    return DefWindowProc(hwnd, message, wparam, lparam);
+}
+
+void PreviewHost::PumpStdIn()
+{
+    if (m_stdin == INVALID_HANDLE_VALUE || m_stdin == nullptr)
+    {
+        return;
+    }
+
+    DWORD available = 0;
+    if (m_stdinType == FILE_TYPE_PIPE)
+    {
+        if (!PeekNamedPipe(m_stdin, nullptr, 0, nullptr, &available, nullptr))
+        {
+            const DWORD error = GetLastError();
+            if (error == ERROR_BROKEN_PIPE || error == ERROR_HANDLE_EOF)
+            {
+                m_shutdownRequested = true;
+            }
+            return;
+        }
+
+        if (available == 0)
+        {
+            return;
+        }
+    }
+    else
+    {
+        // The Avalonia client uses redirected pipes. Avoid blocking when launched manually.
+        return;
+    }
+
+    char readBuffer[512];
+    DWORD toRead = std::min<DWORD>(available, static_cast<DWORD>(sizeof(readBuffer)));
+    DWORD bytesRead = 0;
+    if (!ReadFile(m_stdin, readBuffer, toRead, &bytesRead, nullptr))
+    {
+        const DWORD error = GetLastError();
+        if (error == ERROR_BROKEN_PIPE || error == ERROR_HANDLE_EOF)
+        {
+            m_shutdownRequested = true;
+        }
+        return;
+    }
+
+    if (bytesRead == 0)
+    {
+        return;
+    }
+
+    for (DWORD i = 0; i < bytesRead; ++i)
+    {
+        const char ch = readBuffer[i];
+        if (ch == '\n' || ch == '\r')
+        {
+            if (m_inputPos > 0)
+            {
+                m_inputBuffer[m_inputPos] = '\0';
+                ProcessLine(m_inputBuffer);
+                m_inputPos = 0;
+            }
+        }
+        else if (m_inputPos < static_cast<int>(sizeof(m_inputBuffer)) - 1)
+        {
+            m_inputBuffer[m_inputPos++] = ch;
+        }
+        else
+        {
+            m_inputPos = 0;
+            SendError("IPC command exceeded input buffer");
+        }
+    }
+}
+
+void PreviewHost::ProcessLine(const char* line)
+{
+    const IpcCommandType commandType = IpcParser::ParseCommandType(line);
+    if (!m_protocolReady
+        && commandType != IpcCommandType::Init
+        && commandType != IpcCommandType::Shutdown)
+    {
+        SendError("Preview host has not been initialized", line);
+        return;
+    }
+
+    switch (commandType)
+    {
+    case IpcCommandType::Init:
+    {
+        IpcInitCommand command;
+        if (IpcParser::ParseInit(line, command))
+        {
+            HandleInit(command);
+        }
+        else
+        {
+            SendError("Invalid init command", line);
+        }
+        break;
+    }
+
+    case IpcCommandType::Shutdown:
+        HandleShutdown();
+        break;
+
+    case IpcCommandType::AttachWindow:
+    {
+        IpcAttachWindowCommand command;
+        if (IpcParser::ParseAttachWindow(line, command))
+        {
+            HandleAttachWindow(command);
+        }
+        else
+        {
+            SendError("Invalid attachWindow command", line);
+        }
+        break;
+    }
+
+    case IpcCommandType::LoadEntity:
+    {
+        IpcLoadEntityCommand command;
+        if (IpcParser::ParseLoadEntity(line, command))
+        {
+            HandleLoadEntity(command);
+        }
+        else
+        {
+            SendError("Invalid loadEntity command", line);
+        }
+        break;
+    }
+
+    case IpcCommandType::LoadParticle:
+    {
+        IpcLoadParticleCommand command;
+        if (IpcParser::ParseLoadParticle(line, command))
+        {
+            HandleLoadParticle(command);
+        }
+        else
+        {
+            SendError("Invalid loadParticle command", line);
+        }
+        break;
+    }
+
+    case IpcCommandType::Tick:
+        break;
+
+    case IpcCommandType::Pick:
+    {
+        IpcPickCommand command;
+        if (IpcParser::ParsePick(line, command))
+        {
+            HandlePick(command);
+        }
+        else
+        {
+            SendError("Invalid pick command", line);
+        }
+        break;
+    }
+
+    case IpcCommandType::SetCameraPosition:
+        SendDiagnostic("info", "Camera command accepted by scaffold");
+        break;
+
+    case IpcCommandType::Unknown:
+    default:
+        SendError("Unknown command type", line);
+        break;
+    }
+}
+
+void PreviewHost::HandleInit(const IpcInitCommand& command)
+{
+    if (command.protocolVersion != IPC_PROTOCOL_VERSION)
+    {
+        char message[128];
+        std::snprintf(message, sizeof(message), "Protocol version mismatch: expected %d, got %d",
+            IPC_PROTOCOL_VERSION, command.protocolVersion);
+        SendError(message);
+        return;
+    }
+
+    m_protocolReady = true;
+    SendReady();
+}
+
+void PreviewHost::HandleAttachWindow(const IpcAttachWindowCommand& command)
+{
+    m_parentHwnd = reinterpret_cast<HWND>(static_cast<intptr_t>(command.hwnd));
+
+    if (m_parentHwnd == nullptr || !IsWindow(m_parentHwnd))
+    {
+        SendError("attachWindow received an invalid HWND");
+        return;
+    }
+
+    SetParent(m_hwnd, m_parentHwnd);
+    SetWindowLongPtr(m_hwnd, GWL_STYLE, WS_CHILD | WS_VISIBLE | WS_CLIPCHILDREN | WS_CLIPSIBLINGS);
+    SetWindowLongPtr(m_hwnd, GWL_EXSTYLE, 0);
+    ResizeHostedWindow(command.width, command.height);
+    SetWindowPos(m_hwnd, nullptr, 0, 0, 0, 0,
+        SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
+    ShowWindow(m_hwnd, SW_SHOW);
+
+    char message[128];
+    std::snprintf(message, sizeof(message), "Attached native preview window: %dx%d", command.width, command.height);
+    SendDiagnostic("info", message);
+}
+
+void PreviewHost::HandleLoadEntity(const IpcLoadEntityCommand& command)
+{
+    SendLoaded("entity", command.path, false, "Entity preview rendering is not implemented in the scaffold");
+}
+
+void PreviewHost::HandleLoadParticle(const IpcLoadParticleCommand& command)
+{
+    const char* path = command.effectPath[0] != '\0' ? command.effectPath : command.emitterPath;
+    SendLoaded("particle", path, false, "Particle preview rendering is not implemented in the scaffold");
+}
+
+void PreviewHost::HandlePick(const IpcPickCommand& command)
+{
+    UNREFERENCED_PARAMETER(command);
+
+    char response[128];
+    IpcResponse::Picked(response, sizeof(response), nullptr, nullptr);
+    SendResponse(response);
+}
+
+void PreviewHost::HandleShutdown()
+{
+    SendDiagnostic("info", "Shutdown requested");
+    m_shutdownRequested = true;
+}
+
+void PreviewHost::ResizeHostedWindow(int width, int height)
+{
+    if (m_hwnd == nullptr)
+    {
+        return;
+    }
+
+    MoveWindow(m_hwnd, 0, 0, std::max(width, 1), std::max(height, 1), TRUE);
+}
+
+void PreviewHost::SendResponse(const char* json)
+{
+    if (m_stdout == INVALID_HANDLE_VALUE || m_stdout == nullptr)
+    {
+        return;
+    }
+
+    DWORD written = 0;
+    WriteFile(m_stdout, json, static_cast<DWORD>(std::strlen(json)), &written, nullptr);
+    WriteFile(m_stdout, "\n", 1, &written, nullptr);
+}
+
+void PreviewHost::SendReady()
+{
+    char buffer[256];
+    IpcResponse::Ready(buffer, sizeof(buffer), IPC_PROTOCOL_VERSION, kEngineVersion);
+    SendResponse(buffer);
+}
+
+void PreviewHost::SendError(const char* message, const char* details)
+{
+    char buffer[1024];
+    IpcResponse::Error(buffer, sizeof(buffer), message, details);
+    SendResponse(buffer);
+}
+
+void PreviewHost::SendLoaded(const char* resourceType, const char* path, bool success, const char* error)
+{
+    char buffer[1024];
+    IpcResponse::Loaded(buffer, sizeof(buffer), resourceType, path, success, error);
+    SendResponse(buffer);
+}
+
+void PreviewHost::SendDiagnostic(const char* level, const char* message, const char* source)
+{
+    char buffer[1024];
+    IpcResponse::Diagnostic(buffer, sizeof(buffer), level, message, source);
+    SendResponse(buffer);
+}

--- a/Tools/Source/UsagiPreviewHost/PreviewHost.h
+++ b/Tools/Source/UsagiPreviewHost/PreviewHost.h
@@ -1,0 +1,54 @@
+/****************************************************************************
+//  Minimal native preview host for Avalonia tools.
+****************************************************************************/
+#pragma once
+
+#ifndef USAGI_PREVIEW_HOST_H
+#define USAGI_PREVIEW_HOST_H
+
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+
+#include "IpcProtocol.h"
+
+class PreviewHost
+{
+public:
+    PreviewHost();
+    ~PreviewHost();
+
+    int Run(HINSTANCE instance, int showCommand);
+
+private:
+    static LRESULT CALLBACK WindowProc(HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam);
+
+    bool CreatePreviewWindow(HINSTANCE instance);
+    void PumpStdIn();
+    void ProcessLine(const char* line);
+    void HandleInit(const IpcInitCommand& command);
+    void HandleAttachWindow(const IpcAttachWindowCommand& command);
+    void HandleLoadEntity(const IpcLoadEntityCommand& command);
+    void HandleLoadParticle(const IpcLoadParticleCommand& command);
+    void HandlePick(const IpcPickCommand& command);
+    void HandleShutdown();
+
+    void ResizeHostedWindow(int width, int height);
+    void SendResponse(const char* json);
+    void SendReady();
+    void SendError(const char* message, const char* details = nullptr);
+    void SendLoaded(const char* resourceType, const char* path, bool success, const char* error = nullptr);
+    void SendDiagnostic(const char* level, const char* message, const char* source = nullptr);
+
+    HWND m_hwnd;
+    HWND m_parentHwnd;
+    HANDLE m_stdin;
+    HANDLE m_stdout;
+    DWORD m_stdinType;
+    bool m_shutdownRequested;
+    bool m_protocolReady;
+    char m_inputBuffer[8192];
+    int m_inputPos;
+};
+
+#endif

--- a/Tools/Source/UsagiPreviewHost/main/_win/WinMain.cpp
+++ b/Tools/Source/UsagiPreviewHost/main/_win/WinMain.cpp
@@ -1,0 +1,13 @@
+/****************************************************************************
+//  Usagi preview host Win32 entry point.
+****************************************************************************/
+#include "..\..\PreviewHost.h"
+
+int WINAPI WinMain(HINSTANCE instance, HINSTANCE previousInstance, LPSTR commandLine, int showCommand)
+{
+    UNREFERENCED_PARAMETER(previousInstance);
+    UNREFERENCED_PARAMETER(commandLine);
+
+    PreviewHost host;
+    return host.Run(instance, showCommand);
+}

--- a/Tools/Source/UsagiPreviewHost/project/UsagiPreviewHost.vcxproj
+++ b/Tools/Source/UsagiPreviewHost/project/UsagiPreviewHost.vcxproj
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{2CB9B489-5240-41E0-A958-2CB60F188B43}</ProjectGuid>
+    <RootNamespace>UsagiPreviewHost</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <TargetName>UsagiPreviewHost</TargetName>
+    <OutDir Condition="'$(USAGI_DIR)'!=''">$(USAGI_DIR)\Tools\bin\</OutDir>
+    <OutDir Condition="'$(USAGI_DIR)'==''">$(MSBuildProjectDirectory)\..\..\..\bin\</OutDir>
+    <IntDir>$(MSBuildProjectDirectory)\_build\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_WINDOWS;_CRT_SECURE_NO_WARNINGS;PREVIEW_HOST;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <ExceptionHandling>false</ExceptionHandling>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <AdditionalDependencies>user32.lib;gdi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_WINDOWS;_CRT_SECURE_NO_WARNINGS;PREVIEW_HOST;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <ExceptionHandling>false</ExceptionHandling>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <SubSystem>Windows</SubSystem>
+      <AdditionalDependencies>user32.lib;gdi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\IpcProtocol.cpp" />
+    <ClCompile Include="..\PreviewHost.cpp" />
+    <ClCompile Include="..\main\_win\WinMain.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\IpcProtocol.h" />
+    <ClInclude Include="..\PreviewHost.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+</Project>

--- a/Tools/Source/UsagiPreviewHost/project/UsagiPreviewHost.vcxproj.filters
+++ b/Tools/Source/UsagiPreviewHost/project/UsagiPreviewHost.vcxproj.filters
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{5325685C-2A94-4A5B-A395-F68E61393BB6}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Platform">
+      <UniqueIdentifier>{4C56DA1F-1787-4373-9370-650DE68DE2C5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{2DDE0392-EEA4-47F5-A8E6-9B280B2E26C1}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\IpcProtocol.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\PreviewHost.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\main\_win\WinMain.cpp">
+      <Filter>Source Files\Platform</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\IpcProtocol.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\PreviewHost.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/Tools/Tests/PreviewHost/Run.ps1
+++ b/Tools/Tests/PreviewHost/Run.ps1
@@ -1,0 +1,177 @@
+param(
+    [ValidateSet("Debug", "Release")]
+    [string]$Configuration = "Debug",
+    [ValidateSet("x64")]
+    [string]$Platform = "x64",
+    [int]$TimeoutSeconds = 15,
+    [switch]$SkipBuild
+)
+
+$ErrorActionPreference = "Stop"
+
+function Get-RepoRoot {
+    $root = (Resolve-Path $PSScriptRoot).Path
+    while ($root -and !(Test-Path (Join-Path $root "Engine\CommonProps.props"))) {
+        $parent = Split-Path $root -Parent
+        if ($parent -eq $root) {
+            break
+        }
+
+        $root = $parent
+    }
+
+    if (!$root -or !(Test-Path (Join-Path $root "Engine\CommonProps.props"))) {
+        throw "Could not locate Usagi repository root from $PSScriptRoot"
+    }
+
+    return $root
+}
+
+function Get-MSBuild {
+    $fromPath = Get-Command msbuild.exe -ErrorAction SilentlyContinue
+    if ($fromPath) {
+        return $fromPath.Source
+    }
+
+    $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+    if (Test-Path $vswhere) {
+        $found = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -find "MSBuild\**\Bin\MSBuild.exe" | Select-Object -First 1
+        if ($found) {
+            return $found
+        }
+    }
+
+    throw "MSBuild.exe was not found. Install Visual Studio Build Tools with C++ workload or run from a Developer PowerShell."
+}
+
+function Send-Json([System.Diagnostics.Process]$Process, [string]$Json) {
+    $Process.StandardInput.WriteLine($Json)
+    $Process.StandardInput.Flush()
+}
+
+function Wait-ForLine {
+    param(
+        [System.Diagnostics.Process]$Process,
+        [scriptblock]$Predicate,
+        [string]$Description,
+        [int]$TimeoutSeconds
+    )
+
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    $seen = New-Object System.Collections.Generic.List[string]
+    $readTask = $null
+
+    while ([DateTime]::UtcNow -lt $deadline) {
+        if ($null -eq $readTask) {
+            $readTask = $Process.StandardOutput.ReadLineAsync()
+        }
+
+        if ($readTask.Wait(50)) {
+            $line = $readTask.Result
+            $readTask = $null
+            if ($null -eq $line) {
+                break
+            }
+
+            $seen.Add($line)
+            if (& $Predicate $line) {
+                return $line
+            }
+        }
+
+        if ($Process.HasExited) {
+            break
+        }
+    }
+
+    $exitDetails = ""
+    if ($Process.HasExited) {
+        $exitDetails = "Process exited with code $($Process.ExitCode)."
+    }
+
+    $stderr = ""
+    if ($Process.HasExited) {
+        $stderr = $Process.StandardError.ReadToEnd()
+    }
+
+    throw "Timed out waiting for $Description. $exitDetails`nstdout:`n$($seen -join "`n")`nstderr:`n$stderr"
+}
+
+$repoRoot = Get-RepoRoot
+$env:USAGI_DIR = $repoRoot
+
+$projectPath = Join-Path $repoRoot "Tools\Source\UsagiPreviewHost\project\UsagiPreviewHost.vcxproj"
+$hostPath = Join-Path $repoRoot "Tools\bin\UsagiPreviewHost.exe"
+
+if (!$SkipBuild) {
+    $msbuild = Get-MSBuild
+    & $msbuild $projectPath /m /p:Configuration=$Configuration /p:Platform=$Platform /v:minimal
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+}
+
+if (!(Test-Path $hostPath)) {
+    throw "Preview host executable was not found: $hostPath"
+}
+
+$startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+$startInfo.FileName = $hostPath
+$startInfo.WorkingDirectory = $repoRoot
+$startInfo.UseShellExecute = $false
+$startInfo.CreateNoWindow = $true
+$startInfo.RedirectStandardInput = $true
+$startInfo.RedirectStandardOutput = $true
+$startInfo.RedirectStandardError = $true
+
+$process = [System.Diagnostics.Process]::new()
+$process.StartInfo = $startInfo
+
+try {
+    [void]$process.Start()
+
+    Send-Json $process '{"type":"pick","x":1,"y":2}'
+    [void](Wait-ForLine $process { param($line) $line -match '"type":"error"' -and $line -match 'not been initialized' } "pre-init protocol error" $TimeoutSeconds)
+
+    $dataPath = (Join-Path $repoRoot "Data").Replace("\", "\\")
+    $romfilesPath = (Join-Path $repoRoot "_romfiles\win").Replace("\", "\\")
+    Send-Json $process "{`"type`":`"init`",`"protocolVersion`":1,`"dataPath`":`"$dataPath`",`"romfilesPath`":`"$romfilesPath`"}"
+    [void](Wait-ForLine $process { param($line) $line -match '"type":"ready"' -and $line -match '"protocolVersion":1' } "ready response" $TimeoutSeconds)
+
+    Send-Json $process '{"type":"loadEntity","path":"Data/Entities/PreviewSmoke.yml"}'
+    [void](Wait-ForLine $process { param($line) $line -match '"type":"loaded"' -and $line -match '"resourceType":"entity"' -and $line -match '"success":false' } "stub entity load response" $TimeoutSeconds)
+
+    Send-Json $process '{"type":"loadParticle","emitterPath":"Data/Particle/Emitters/PreviewSmoke.yml","effectPath":null}'
+    [void](Wait-ForLine $process { param($line) $line -match '"type":"loaded"' -and $line -match '"resourceType":"particle"' -and $line -match '"success":false' } "stub particle load response" $TimeoutSeconds)
+
+    Send-Json $process '{"type":"pick","x":4,"y":8}'
+    [void](Wait-ForLine $process { param($line) $line -match '"type":"picked"' -and $line -match '"entityId":null' } "empty pick response" $TimeoutSeconds)
+
+    Send-Json $process '{"type":"shutdown"}'
+    if (!$process.WaitForExit($TimeoutSeconds * 1000)) {
+        $process.Kill()
+        throw "Preview host did not exit after shutdown."
+    }
+
+    if ($process.ExitCode -ne 0) {
+        $stderr = $process.StandardError.ReadToEnd()
+        throw "Preview host exited with code $($process.ExitCode).`nstderr:`n$stderr"
+    }
+
+    Write-Host "Preview host headless smoke passed."
+}
+finally {
+    if (!$process.HasExited) {
+        try {
+            Send-Json $process '{"type":"shutdown"}'
+            if (!$process.WaitForExit(1000)) {
+                $process.Kill()
+            }
+        }
+        catch {
+            try { $process.Kill() } catch { }
+        }
+    }
+
+    $process.Dispose()
+}


### PR DESCRIPTION
This adds a standalone native `UsagiPreviewHost.exe` scaffold with JSON-lines
IPC and a headless smoke test, while deferring renderer/resource integration to
later preview PRs.

Why this makes sense:

- The tool preview work needs a stable native process boundary before it can
  safely embed engine rendering into managed editor UI.
- A protocol-only scaffold lets managed and native work agree on startup,
  shutdown, diagnostics, and window attachment without taking on Vulkan/resource
  lifetime yet.
- Keeping this PR native-only avoids coupling it to the managed `UsagiTools`
  branches still under review.

What changed:

- Added `Tools/Source/UsagiPreviewHost` with a Win32 hidden-window host,
  protocol parser, JSON responses, attach-window handling, init gate, stub
  load/tick/pick/camera commands, and shutdown.
- Added `Tools/Tests/PreviewHost/Run.ps1` to build the host and exercise
  protocol startup, stub responses, picking, and shutdown.
- Added `Documents/PreviewHost.md` documenting the scaffold and the next engine
  integration step.
- Did not add managed preview client files or model/particle asset loading.

Validation:

- `powershell -NoProfile -ExecutionPolicy Bypass -File Tools/Tests/PreviewHost/Run.ps1` passed.
- The test built Debug x64 with MSBuild and reported `Preview host headless smoke passed.`
- `git diff --check`