### PR TITLE
Load model and particle assets in preview host

### DIFF
--- a/Tools/Source/UsagiPreviewHost/PreviewEngineBridge.cpp
+++ b/Tools/Source/UsagiPreviewHost/PreviewEngineBridge.cpp
@@ -1,0 +1,766 @@
+/****************************************************************************
+//  Usagi engine bridge for the native preview host.
+****************************************************************************/
+#include "PreviewEngineBridge.h"
+
+#include "Engine/Common/Common.h"
+#include "Engine/Core/_win/WinUtil.h"
+#include "Engine/Core/Modules/ModuleManager.h"
+#include "Engine/Game/GameInterface.h"
+#include "Engine/Graphics/Device/Display.h"
+#include "Engine/Graphics/Device/GFXContext.h"
+#include "Engine/Graphics/Device/GFXDevice.h"
+#include "Engine/Graphics/Textures/RenderTarget.h"
+#include "Engine/HID/Input.h"
+#include "Engine/Maths/AABB.h"
+#include "Engine/Particles/ParticleEffect.h"
+#include "Engine/Particles/ParticleEffectHndl.h"
+#include "Engine/Particles/Scripted/ScriptEmitter.h"
+#include "Engine/PostFX/PostFXSys.h"
+#include "Engine/Resource/ModelResource.h"
+#include "Engine/Resource/ResourceMgr.h"
+#include "Engine/Scene/Camera/StandardCamera.h"
+#include "Engine/Scene/Model/Model.h"
+#include "Engine/Scene/Scene.h"
+#include "Engine/Scene/ViewContext.h"
+#include "Engine/Graphics/Lights/DirLight.h"
+#include "Engine/Graphics/Lights/LightMgr.h"
+#include OS_HEADER(Engine/HID, Input_ps.h)
+
+#include <algorithm>
+#include <cctype>
+#include <cstdio>
+#include <cstring>
+
+namespace usg
+{
+bool InitEngine(const char** dllModules, uint32 uModuleCount);
+bool GameInit();
+void GameLoop();
+void GameCleanup();
+void GameMessage(const uint32 messageID, const void* const pParameters);
+GFXDevice* GetGFXDevice();
+}
+
+namespace
+{
+static const float kDefaultDeltaTime = 1.0f / 60.0f;
+class PreviewGame;
+static PreviewGame* g_previewGame = nullptr;
+
+bool FileExists(const char* path)
+{
+    const DWORD attributes = GetFileAttributesA(path);
+    return attributes != INVALID_FILE_ATTRIBUTES && (attributes & FILE_ATTRIBUTE_DIRECTORY) == 0;
+}
+
+void CopyResourceName(const char* path, char* out, int outSize)
+{
+    if (outSize <= 0)
+    {
+        return;
+    }
+
+    out[0] = '\0';
+    if (path == nullptr || path[0] == '\0')
+    {
+        return;
+    }
+
+    const char* nameStart = path;
+    for (const char* cursor = path; *cursor != '\0'; ++cursor)
+    {
+        if (*cursor == '\\' || *cursor == '/')
+        {
+            nameStart = cursor + 1;
+        }
+    }
+
+    std::snprintf(out, outSize, "%s", nameStart);
+
+    for (char* cursor = out; *cursor != '\0'; ++cursor)
+    {
+        if (*cursor == '.')
+        {
+            *cursor = '\0';
+            break;
+        }
+    }
+}
+
+bool ValidateCompiledParticleFile(const char* resourceName, const char* extension, char* error, int errorSize)
+{
+    char relativePath[MAX_PATH] = {};
+    std::snprintf(relativePath, sizeof(relativePath), "Particle/%s.%s", resourceName, extension);
+
+    if (FileExists(relativePath))
+    {
+        return true;
+    }
+
+    std::snprintf(error, errorSize, "Compiled particle resource not found: %s", relativePath);
+    return false;
+}
+
+void NormalizeSlashes(char* path)
+{
+    for (char* cursor = path; *cursor != '\0'; ++cursor)
+    {
+        if (*cursor == '\\')
+        {
+            *cursor = '/';
+        }
+    }
+}
+
+bool EndsWithInsensitive(const char* value, const char* suffix)
+{
+    const size_t valueLen = std::strlen(value);
+    const size_t suffixLen = std::strlen(suffix);
+    if (valueLen < suffixLen)
+    {
+        return false;
+    }
+
+    const char* valueSuffix = value + valueLen - suffixLen;
+    for (size_t i = 0; i < suffixLen; ++i)
+    {
+        if (std::tolower(static_cast<unsigned char>(valueSuffix[i])) != std::tolower(static_cast<unsigned char>(suffix[i])))
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void TrimAscii(char* value)
+{
+    char* start = value;
+    while (*start != '\0' && std::isspace(static_cast<unsigned char>(*start)))
+    {
+        ++start;
+    }
+
+    char* end = start + std::strlen(start);
+    while (end > start && std::isspace(static_cast<unsigned char>(end[-1])))
+    {
+        --end;
+    }
+
+    *end = '\0';
+    if (start != value)
+    {
+        std::memmove(value, start, std::strlen(start) + 1);
+    }
+}
+
+bool ExtractModelResourceName(const char* path, char* out, int outSize)
+{
+    if (path == nullptr || path[0] == '\0' || outSize <= 0)
+    {
+        return false;
+    }
+
+    std::snprintf(out, outSize, "%s", path);
+    NormalizeSlashes(out);
+
+    const char* marker = std::strstr(out, "Data/Models/");
+    if (marker != nullptr)
+    {
+        std::memmove(out, marker + std::strlen("Data/Models/"), std::strlen(marker + std::strlen("Data/Models/")) + 1);
+    }
+
+    marker = std::strstr(out, "Models/");
+    if (marker == out)
+    {
+        std::memmove(out, out + std::strlen("Models/"), std::strlen(out + std::strlen("Models/")) + 1);
+    }
+
+    TrimAscii(out);
+    return out[0] != '\0';
+}
+
+bool ParseEntityModelName(const char* path, char* out, int outSize, char* error, int errorSize)
+{
+    FILE* file = nullptr;
+    fopen_s(&file, path, "rb");
+    if (file == nullptr)
+    {
+        std::snprintf(error, errorSize, "Could not open entity YAML: %s", path);
+        return false;
+    }
+
+    bool inModelComponent = false;
+    char line[1024] = {};
+    while (std::fgets(line, sizeof(line), file) != nullptr)
+    {
+        char* cursor = line;
+        while (*cursor == ' ' || *cursor == '\t')
+        {
+            ++cursor;
+        }
+
+        if (std::strncmp(cursor, "ModelComponent:", 15) == 0)
+        {
+            inModelComponent = true;
+            continue;
+        }
+
+        if (inModelComponent && cursor == line && cursor[0] != '\0' && cursor[0] != '\r' && cursor[0] != '\n')
+        {
+            inModelComponent = false;
+        }
+
+        if (inModelComponent)
+        {
+            char* name = std::strstr(cursor, "name:");
+            if (name != nullptr)
+            {
+                name += 5;
+                std::snprintf(out, outSize, "%s", name);
+                TrimAscii(out);
+                NormalizeSlashes(out);
+                fclose(file);
+                return out[0] != '\0';
+            }
+        }
+    }
+
+    fclose(file);
+    std::snprintf(error, errorSize, "Entity YAML does not contain a direct ModelComponent.name: %s", path);
+    return false;
+}
+
+bool ValidateCompiledModelFile(const char* modelName, char* error, int errorSize)
+{
+    char relativePath[MAX_PATH] = {};
+    std::snprintf(relativePath, sizeof(relativePath), "Models/%s", modelName);
+
+    if (FileExists(relativePath))
+    {
+        return true;
+    }
+
+    std::snprintf(error, errorSize, "Compiled model resource not found: %s", relativePath);
+    return false;
+}
+
+class PreviewGame final : public usg::GameInterface
+{
+public:
+    PreviewGame()
+        : m_viewContext(nullptr)
+        , m_keyLight(nullptr)
+        , m_previewModel(nullptr)
+        , m_sceneInitialized(false)
+        , m_postFxInitialized(false)
+        , m_singleEmitterAllocated(false)
+        , m_pendingDeltaTime(kDefaultDeltaTime)
+    {
+        m_activeEffectMatrix.LoadIdentity();
+    }
+
+    void Init(usg::GFXDevice* pDevice, usg::ResourceMgr* pResMgr) override
+    {
+        UNREFERENCED_PARAMETER(pResMgr);
+
+        usg::Input::Init();
+        InitScene(pDevice);
+        m_bIsRunning = true;
+    }
+
+    void Cleanup(usg::GFXDevice* pDevice) override
+    {
+        if (pDevice != nullptr)
+        {
+            pDevice->WaitIdle();
+        }
+
+        ClearParticle(pDevice);
+        ClearModel(pDevice);
+
+        if (m_sceneInitialized)
+        {
+            if (m_keyLight != nullptr)
+            {
+                m_scene.GetLightMgr().RemoveDirLight(m_keyLight);
+                m_keyLight = nullptr;
+            }
+
+            if (m_viewContext != nullptr)
+            {
+                m_scene.DeleteViewContext(m_viewContext);
+                m_viewContext = nullptr;
+            }
+
+            m_scene.Cleanup(pDevice);
+            m_sceneInitialized = false;
+        }
+
+        if (m_postFxInitialized)
+        {
+            m_postFx.Cleanup(pDevice);
+            m_postFxInitialized = false;
+        }
+    }
+
+    void Update(usg::GFXDevice* pDevice) override
+    {
+        if (!m_sceneInitialized)
+        {
+            return;
+        }
+
+        m_scene.TransformUpdate(m_pendingDeltaTime);
+        if (m_previewModel != nullptr)
+        {
+            m_previewModel->GPUUpdate(pDevice);
+        }
+        m_scene.Update(pDevice);
+        m_postFx.Update(&m_scene, m_pendingDeltaTime);
+        m_postFx.UpdateGPU(pDevice);
+        m_pendingDeltaTime = kDefaultDeltaTime;
+    }
+
+    void Draw(usg::GFXDevice* pDevice) override
+    {
+        if (pDevice == nullptr)
+        {
+            return;
+        }
+
+        usg::Display* display = pDevice->GetDisplay(0);
+        if (display == nullptr)
+        {
+            return;
+        }
+
+        pDevice->Begin();
+        usg::GFXContext* context = pDevice->GetImmediateCtxt();
+        context->Begin(true);
+
+        if (m_sceneInitialized)
+        {
+            context->ApplyDefaults();
+            m_scene.PreDraw(context);
+
+            m_postFx.BeginScene(context, usg::PostFXSys::TRANSFER_FLAGS_CLEAR);
+            m_postFx.SetActiveViewContext(m_viewContext);
+            m_viewContext->PreDraw(context, usg::VIEW_CENTRAL);
+            m_viewContext->DrawScene(context);
+            m_postFx.SetActiveViewContext(nullptr);
+
+            context->Transfer(m_postFx.GetFinalRT(), display);
+            m_postFx.EndScene();
+        }
+
+        context->RenderToDisplay(display, usg::RenderTarget::RT_FLAG_COLOR_0 | usg::RenderTarget::RT_FLAG_DEPTH);
+        display->Present();
+        context->End();
+        pDevice->End();
+    }
+
+    void OnMessage(usg::GFXDevice* const pDevice, const uint32 messageID, const void* const pParameters) override
+    {
+        UNREFERENCED_PARAMETER(pParameters);
+
+        if (pDevice == nullptr)
+        {
+            return;
+        }
+
+        switch (messageID)
+        {
+        case 'ONSZ':
+            pDevice->WaitIdle();
+            break;
+        case 'WSZE':
+            if (usg::Display* display = pDevice->GetDisplay(0))
+            {
+                display->Resize(pDevice);
+                if (m_postFxInitialized)
+                {
+                    m_postFx.UpdateRTSize(pDevice, display);
+                    uint32 width = 0;
+                    uint32 height = 0;
+                    display->GetDisplayDimensions(width, height, false);
+                    SetCameraPosition(0.0f, 0.0f, 25.0f, 0.0f, 0.0f, 0.0f, width, height);
+                }
+            }
+            break;
+        case 'WMIN':
+            if (usg::Display* display = pDevice->GetDisplay(0))
+            {
+                display->Minimized(pDevice);
+            }
+            break;
+        default:
+            break;
+        }
+    }
+
+    bool LoadEntity(usg::GFXDevice* pDevice, const char* path, char* error, int errorSize)
+    {
+        if (!m_sceneInitialized)
+        {
+            std::snprintf(error, errorSize, "Preview scene is not initialized.");
+            return false;
+        }
+
+        char modelName[MAX_PATH] = {};
+        if (EndsWithInsensitive(path, ".yml") || EndsWithInsensitive(path, ".yaml"))
+        {
+            if (!ParseEntityModelName(path, modelName, sizeof(modelName), error, errorSize))
+            {
+                return false;
+            }
+        }
+        else if (!ExtractModelResourceName(path, modelName, sizeof(modelName)))
+        {
+            std::snprintf(error, errorSize, "Entity preview requires an entity YAML or model resource path.");
+            return false;
+        }
+
+        if (!ValidateCompiledModelFile(modelName, error, errorSize))
+        {
+            return false;
+        }
+
+        ClearParticle(pDevice);
+        ClearModel(pDevice);
+
+        m_previewModel = vnew(usg::ALLOC_OBJECT) usg::Model();
+        if (!m_previewModel->Load(pDevice, &m_scene, usg::ResourceMgr::Inst(), modelName, false, true, true, true))
+        {
+            vdelete m_previewModel;
+            m_previewModel = nullptr;
+            std::snprintf(error, errorSize, "Failed to load model resource: %s", modelName);
+            return false;
+        }
+
+        usg::Matrix4x4 modelMatrix;
+        modelMatrix.LoadIdentity();
+        m_previewModel->SetTransform(modelMatrix);
+        m_previewModel->GPUUpdate(pDevice);
+
+        const usg::Sphere& bounds = m_previewModel->GetResource()->GetBounds();
+        const float radius = std::max(bounds.GetRadius(), 1.0f);
+        const usg::Vector3f center = bounds.GetPos();
+        SetCameraPosition(
+            center.x,
+            center.y + radius * 0.35f,
+            center.z + radius * 3.5f,
+            center.x,
+            center.y,
+            center.z);
+        return true;
+    }
+
+    bool LoadParticle(usg::GFXDevice* pDevice, const char* emitterPath, const char* effectPath, char* error, int errorSize)
+    {
+        if (!m_sceneInitialized)
+        {
+            std::snprintf(error, errorSize, "Preview scene is not initialized.");
+            return false;
+        }
+
+        char emitterName[MAX_PATH] = {};
+        char effectName[MAX_PATH] = {};
+        CopyResourceName(emitterPath, emitterName, sizeof(emitterName));
+        CopyResourceName(effectPath, effectName, sizeof(effectName));
+
+        if (effectName[0] != '\0')
+        {
+            if (!ValidateCompiledParticleFile(effectName, "pfx", error, errorSize))
+            {
+                return false;
+            }
+
+            ClearModel(pDevice);
+            ClearParticle(pDevice);
+
+            usg::Matrix4x4 matrix;
+            matrix.LoadIdentity();
+            m_scene.CreateScriptedEffect(m_activeEffect, matrix, effectName);
+            m_activeEffectMatrix = matrix;
+            return true;
+        }
+
+        if (emitterName[0] == '\0')
+        {
+            std::snprintf(error, errorSize, "Particle load requires an emitter or effect path.");
+            return false;
+        }
+
+        if (!ValidateCompiledParticleFile(emitterName, "pem", error, errorSize))
+        {
+            return false;
+        }
+
+        ClearParticle(pDevice);
+        ClearModel(pDevice);
+
+        usg::Matrix4x4 matrix;
+        matrix.LoadIdentity();
+        m_singleEmitterEffect.Init(pDevice, &m_scene, matrix);
+        m_singleEmitter.Alloc(pDevice, &m_scene.GetParticleMgr(), emitterName, true);
+        m_singleEmitter.SetInstanceData(matrix, 1.0f, 0.0f, 0);
+        m_singleEmitterEffect.AddEmitter(pDevice, &m_singleEmitter);
+        m_singleEmitterAllocated = true;
+        m_activeEffectMatrix = matrix;
+        return true;
+    }
+
+    void SetDeltaTime(float deltaTime)
+    {
+        if (deltaTime > 0.0f)
+        {
+            m_pendingDeltaTime = deltaTime;
+        }
+    }
+
+    void SetCameraPosition(
+        float x,
+        float y,
+        float z,
+        float targetX,
+        float targetY,
+        float targetZ,
+        uint32 width = 0,
+        uint32 height = 0)
+    {
+        if (!m_postFxInitialized)
+        {
+            return;
+        }
+
+        if (width == 0 || height == 0)
+        {
+            width = m_postFx.GetFinalTargetWidth(false);
+            height = m_postFx.GetFinalTargetHeight(false);
+        }
+
+        const float aspect = height > 0 ? static_cast<float>(width) / static_cast<float>(height) : 1.0f;
+        usg::Matrix4x4 cameraMatrix;
+        cameraMatrix.LookAt(usg::Vector3f(x, y, z), usg::Vector3f(targetX, targetY, targetZ), usg::Vector3f::Y_AXIS);
+        m_camera.SetUp(cameraMatrix, aspect, 60.0f, 1.0f, 500.0f);
+    }
+
+private:
+    void InitScene(usg::GFXDevice* pDevice)
+    {
+        if (pDevice == nullptr || m_sceneInitialized)
+        {
+            return;
+        }
+
+        usg::Display* display = pDevice->GetDisplay(0);
+        uint32 width = 640;
+        uint32 height = 480;
+        if (display != nullptr)
+        {
+            display->GetDisplayDimensions(width, height, false);
+        }
+        if (width == 0)
+        {
+            width = 640;
+        }
+        if (height == 0)
+        {
+            height = 480;
+        }
+
+        m_postFx.Init(pDevice, usg::ResourceMgr::Inst(), width, height, usg::PostFXSys::EFFECT_OFFSCREEN_TARGET);
+        m_postFxInitialized = true;
+
+        usg::AABB worldBounds;
+        worldBounds.SetCentreRadii(usg::Vector3f(0.0f, 0.0f, 0.0f), usg::Vector3f(512.0f, 512.0f, 512.0f));
+        m_scene.Init(pDevice, usg::ResourceMgr::Inst(), worldBounds, nullptr);
+        m_viewContext = m_scene.CreateViewContext(pDevice);
+        m_viewContext->Init(pDevice, usg::ResourceMgr::Inst(), &m_postFx, 0, usg::RenderMask::RENDER_MASK_ALL);
+        m_viewContext->SetCamera(&m_camera);
+        m_keyLight = m_scene.GetLightMgr().AddDirectionalLight(pDevice, false, "PreviewKeyLight");
+        m_keyLight->SetDirection(usg::Vector4f(-0.4f, -0.8f, -0.35f, 0.0f));
+        m_keyLight->SetDiffuse(usg::Color(1.0f, 1.0f, 1.0f, 1.0f));
+        m_keyLight->SetAmbient(usg::Color(0.25f, 0.25f, 0.25f, 1.0f));
+        m_keyLight->SetSpecularColor(usg::Color(0.8f, 0.8f, 0.8f, 1.0f));
+        SetCameraPosition(0.0f, 0.0f, 25.0f, 0.0f, 0.0f, 0.0f, width, height);
+        m_sceneInitialized = true;
+    }
+
+    void ClearParticle(usg::GFXDevice* pDevice)
+    {
+        if (pDevice != nullptr)
+        {
+            pDevice->WaitIdle();
+        }
+
+        m_activeEffect.Kill(true);
+
+        if (m_singleEmitterAllocated)
+        {
+            m_singleEmitterEffect.Kill(true);
+            m_singleEmitter.Cleanup(pDevice);
+            m_singleEmitterAllocated = false;
+        }
+    }
+
+    void ClearModel(usg::GFXDevice* pDevice)
+    {
+        if (m_previewModel == nullptr)
+        {
+            return;
+        }
+
+        if (pDevice != nullptr)
+        {
+            pDevice->WaitIdle();
+        }
+
+        m_previewModel->ForceRemoveFromScene();
+        m_previewModel->Cleanup(pDevice);
+        vdelete m_previewModel;
+        m_previewModel = nullptr;
+    }
+
+    usg::Scene m_scene;
+    usg::PostFXSys m_postFx;
+    usg::ViewContext* m_viewContext;
+    usg::DirLight* m_keyLight;
+    usg::StandardCamera m_camera;
+    usg::Model* m_previewModel;
+    usg::ParticleEffectHndl m_activeEffect;
+    usg::ParticleEffect m_singleEmitterEffect;
+    usg::ScriptEmitter m_singleEmitter;
+    usg::Matrix4x4 m_activeEffectMatrix;
+    bool m_sceneInitialized;
+    bool m_postFxInitialized;
+    bool m_singleEmitterAllocated;
+    float m_pendingDeltaTime;
+};
+}
+
+usg::GameInterface* usg::CreateGame()
+{
+    g_previewGame = vnew(usg::ALLOC_OBJECT) PreviewGame();
+    return g_previewGame;
+}
+
+const char* usg::GetGameName()
+{
+    return "Usagi Preview Host";
+}
+
+PreviewEngineBridge::PreviewEngineBridge()
+    : m_initialized(false)
+{
+}
+
+PreviewEngineBridge::~PreviewEngineBridge()
+{
+    Shutdown();
+}
+
+bool PreviewEngineBridge::Initialize(HINSTANCE instance, HWND hwnd, const char* romfilesPath, char* error, int errorSize)
+{
+    if (m_initialized)
+    {
+        return true;
+    }
+
+    if (hwnd == nullptr || !IsWindow(hwnd))
+    {
+        std::snprintf(error, errorSize, "Preview engine received an invalid HWND.");
+        return false;
+    }
+
+    WINUTIL::Init(instance);
+    WINUTIL::SetWindow(hwnd);
+    usg::Input::GetPlatform().RegisterHwnd(0, hwnd);
+
+    if (romfilesPath != nullptr && romfilesPath[0] != '\0' && !SetCurrentDirectoryA(romfilesPath))
+    {
+        std::snprintf(error, errorSize, "Failed to set preview working directory: %s", romfilesPath);
+        return false;
+    }
+
+    if (!usg::InitEngine(nullptr, 0))
+    {
+        std::snprintf(error, errorSize, "Usagi engine initialization failed.");
+        return false;
+    }
+
+    if (!usg::GameInit())
+    {
+        std::snprintf(error, errorSize, "Usagi preview game initialization failed.");
+        usg::GameCleanup();
+        return false;
+    }
+
+    usg::ModuleManager::Inst()->PostInit(usg::GetGFXDevice());
+    m_initialized = true;
+    return true;
+}
+
+bool PreviewEngineBridge::LoadEntity(const char* path, char* error, int errorSize)
+{
+    if (!m_initialized || g_previewGame == nullptr)
+    {
+        std::snprintf(error, errorSize, "Preview engine is not initialized.");
+        return false;
+    }
+
+    return g_previewGame->LoadEntity(usg::GetGFXDevice(), path, error, errorSize);
+}
+
+bool PreviewEngineBridge::LoadParticle(const char* emitterPath, const char* effectPath, char* error, int errorSize)
+{
+    if (!m_initialized || g_previewGame == nullptr)
+    {
+        std::snprintf(error, errorSize, "Preview engine is not initialized.");
+        return false;
+    }
+
+    return g_previewGame->LoadParticle(usg::GetGFXDevice(), emitterPath, effectPath, error, errorSize);
+}
+
+void PreviewEngineBridge::Tick(float deltaTime)
+{
+    if (m_initialized)
+    {
+        if (g_previewGame != nullptr)
+        {
+            g_previewGame->SetDeltaTime(deltaTime);
+        }
+
+        usg::GameLoop();
+    }
+}
+
+void PreviewEngineBridge::SetCameraPosition(float x, float y, float z, float targetX, float targetY, float targetZ)
+{
+    if (m_initialized && g_previewGame != nullptr)
+    {
+        g_previewGame->SetCameraPosition(x, y, z, targetX, targetY, targetZ);
+    }
+}
+
+void PreviewEngineBridge::Resize()
+{
+    if (m_initialized)
+    {
+        usg::GameMessage('ONSZ', nullptr);
+        usg::GameMessage('WSZE', nullptr);
+    }
+}
+
+void PreviewEngineBridge::Shutdown()
+{
+    if (m_initialized)
+    {
+        usg::GameCleanup();
+        g_previewGame = nullptr;
+        m_initialized = false;
+    }
+}

--- a/Tools/Source/UsagiPreviewHost/PreviewEngineBridge.h
+++ b/Tools/Source/UsagiPreviewHost/PreviewEngineBridge.h
@@ -1,0 +1,33 @@
+/****************************************************************************
+//  Usagi engine bridge for the native preview host.
+****************************************************************************/
+#pragma once
+
+#ifndef USAGI_PREVIEW_ENGINE_BRIDGE_H
+#define USAGI_PREVIEW_ENGINE_BRIDGE_H
+
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+
+class PreviewEngineBridge
+{
+public:
+    PreviewEngineBridge();
+    ~PreviewEngineBridge();
+
+    bool Initialize(HINSTANCE instance, HWND hwnd, const char* romfilesPath, char* error, int errorSize);
+    bool LoadEntity(const char* path, char* error, int errorSize);
+    bool LoadParticle(const char* emitterPath, const char* effectPath, char* error, int errorSize);
+    void Tick(float deltaTime);
+    void SetCameraPosition(float x, float y, float z, float targetX, float targetY, float targetZ);
+    void Resize();
+    void Shutdown();
+
+    bool IsInitialized() const { return m_initialized; }
+
+private:
+    bool m_initialized;
+};
+
+#endif

--- a/Tools/Source/UsagiPreviewHost/PreviewHost.cpp
+++ b/Tools/Source/UsagiPreviewHost/PreviewHost.cpp
@@ -8,7 +8,7 @@
 #include <cstring>
 
 static const char* kWindowClassName = "UsagiPreviewHostWindow";
-static const char* kEngineVersion = "UsagiPreviewHost scaffold";
+static const char* kEngineVersion = "UsagiPreviewHost engine bootstrap";
 
 PreviewHost::PreviewHost()
     : m_hwnd(nullptr)
@@ -18,9 +18,11 @@ PreviewHost::PreviewHost()
     , m_stdinType(FILE_TYPE_UNKNOWN)
     , m_shutdownRequested(false)
     , m_protocolReady(false)
+    , m_instance(nullptr)
     , m_inputPos(0)
 {
     std::memset(m_inputBuffer, 0, sizeof(m_inputBuffer));
+    std::memset(&m_initCommand, 0, sizeof(m_initCommand));
     if (m_stdin != INVALID_HANDLE_VALUE && m_stdin != nullptr)
     {
         m_stdinType = GetFileType(m_stdin);
@@ -39,6 +41,7 @@ PreviewHost::~PreviewHost()
 int PreviewHost::Run(HINSTANCE instance, int showCommand)
 {
     UNREFERENCED_PARAMETER(showCommand);
+    m_instance = instance;
 
     if (!CreatePreviewWindow(instance))
     {
@@ -67,6 +70,7 @@ int PreviewHost::Run(HINSTANCE instance, int showCommand)
         Sleep(8);
     }
 
+    m_engine.Shutdown();
     return 0;
 }
 
@@ -292,7 +296,18 @@ void PreviewHost::ProcessLine(const char* line)
     }
 
     case IpcCommandType::Tick:
+    {
+        IpcTickCommand command;
+        if (IpcParser::ParseTick(line, command))
+        {
+            HandleTick(command);
+        }
+        else
+        {
+            SendError("Invalid tick command", line);
+        }
         break;
+    }
 
     case IpcCommandType::Pick:
     {
@@ -309,8 +324,18 @@ void PreviewHost::ProcessLine(const char* line)
     }
 
     case IpcCommandType::SetCameraPosition:
-        SendDiagnostic("info", "Camera command accepted by scaffold");
+    {
+        IpcSetCameraPositionCommand command;
+        if (IpcParser::ParseSetCameraPosition(line, command))
+        {
+            HandleSetCameraPosition(command);
+        }
+        else
+        {
+            SendError("Invalid setCameraPosition command", line);
+        }
         break;
+    }
 
     case IpcCommandType::Unknown:
     default:
@@ -331,6 +356,7 @@ void PreviewHost::HandleInit(const IpcInitCommand& command)
     }
 
     m_protocolReady = true;
+    m_initCommand = command;
     SendReady();
 }
 
@@ -355,17 +381,71 @@ void PreviewHost::HandleAttachWindow(const IpcAttachWindowCommand& command)
     char message[128];
     std::snprintf(message, sizeof(message), "Attached native preview window: %dx%d", command.width, command.height);
     SendDiagnostic("info", message);
+
+    char error[512] = {};
+    if (m_engine.Initialize(m_instance, m_hwnd, m_initCommand.romfilesPath, error, sizeof(error)))
+    {
+        SendDiagnostic("info", "Usagi engine initialized for preview host");
+    }
+    else
+    {
+        SendError("Failed to initialize Usagi preview engine", error);
+    }
 }
 
 void PreviewHost::HandleLoadEntity(const IpcLoadEntityCommand& command)
 {
-    SendLoaded("entity", command.path, false, "Entity preview rendering is not implemented in the scaffold");
+    char error[512] = {};
+    if (m_engine.LoadEntity(command.path, error, sizeof(error)))
+    {
+        SendLoaded("entity", command.path, true);
+    }
+    else
+    {
+        SendLoaded("entity", command.path, false, error);
+    }
 }
 
 void PreviewHost::HandleLoadParticle(const IpcLoadParticleCommand& command)
 {
     const char* path = command.effectPath[0] != '\0' ? command.effectPath : command.emitterPath;
-    SendLoaded("particle", path, false, "Particle preview rendering is not implemented in the scaffold");
+    char error[512] = {};
+    if (m_engine.LoadParticle(command.emitterPath, command.effectPath, error, sizeof(error)))
+    {
+        SendLoaded("particle", path, true);
+    }
+    else
+    {
+        SendLoaded("particle", path, false, error);
+    }
+}
+
+void PreviewHost::HandleTick(const IpcTickCommand& command)
+{
+    if (!m_engine.IsInitialized())
+    {
+        SendDiagnostic("warning", "Tick ignored before preview engine initialization");
+        return;
+    }
+
+    m_engine.Tick(command.deltaTime);
+}
+
+void PreviewHost::HandleSetCameraPosition(const IpcSetCameraPositionCommand& command)
+{
+    if (!m_engine.IsInitialized())
+    {
+        SendDiagnostic("warning", "Camera command ignored before preview engine initialization");
+        return;
+    }
+
+    m_engine.SetCameraPosition(
+        command.x,
+        command.y,
+        command.z,
+        command.targetX,
+        command.targetY,
+        command.targetZ);
 }
 
 void PreviewHost::HandlePick(const IpcPickCommand& command)
@@ -380,6 +460,7 @@ void PreviewHost::HandlePick(const IpcPickCommand& command)
 void PreviewHost::HandleShutdown()
 {
     SendDiagnostic("info", "Shutdown requested");
+    m_engine.Shutdown();
     m_shutdownRequested = true;
 }
 
@@ -391,6 +472,7 @@ void PreviewHost::ResizeHostedWindow(int width, int height)
     }
 
     MoveWindow(m_hwnd, 0, 0, std::max(width, 1), std::max(height, 1), TRUE);
+    m_engine.Resize();
 }
 
 void PreviewHost::SendResponse(const char* json)

--- a/Tools/Source/UsagiPreviewHost/PreviewHost.h
+++ b/Tools/Source/UsagiPreviewHost/PreviewHost.h
@@ -10,6 +10,7 @@
 #define NOMINMAX
 #include <windows.h>
 
+#include "PreviewEngineBridge.h"
 #include "IpcProtocol.h"
 
 class PreviewHost
@@ -30,6 +31,8 @@ private:
     void HandleAttachWindow(const IpcAttachWindowCommand& command);
     void HandleLoadEntity(const IpcLoadEntityCommand& command);
     void HandleLoadParticle(const IpcLoadParticleCommand& command);
+    void HandleTick(const IpcTickCommand& command);
+    void HandleSetCameraPosition(const IpcSetCameraPositionCommand& command);
     void HandlePick(const IpcPickCommand& command);
     void HandleShutdown();
 
@@ -47,6 +50,9 @@ private:
     DWORD m_stdinType;
     bool m_shutdownRequested;
     bool m_protocolReady;
+    HINSTANCE m_instance;
+    IpcInitCommand m_initCommand;
+    PreviewEngineBridge m_engine;
     char m_inputBuffer[8192];
     int m_inputPos;
 };

--- a/Tools/Source/UsagiPreviewHost/project/UsagiPreviewHost.vcxproj
+++ b/Tools/Source/UsagiPreviewHost/project/UsagiPreviewHost.vcxproj
@@ -31,6 +31,14 @@
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\..\..\Engine\CommonProps.props" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\..\..\Engine\CommonProps.props" />
+  </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <TargetName>UsagiPreviewHost</TargetName>
@@ -43,8 +51,8 @@
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;_WINDOWS;_CRT_SECURE_NO_WARNINGS;PREVIEW_HOST;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;$(USAGI_DIR);$(USAGI_DIR)\_includes;$(USAGI_DIR)\Engine\ThirdParty\pthread-w32\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>$(DEFINES);WIN32;_WINDOWS;_CRT_SECURE_NO_WARNINGS;PREVIEW_HOST;PLATFORM_PC;_DEBUG;NW_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <ExceptionHandling>false</ExceptionHandling>
@@ -52,8 +60,15 @@
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>user32.lib;gdi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shlwapi.lib;dxguid.lib;dinput8.lib;vulkan-1.lib;xaudio2.lib;opengl32.lib;glu32.lib;xinput9_1_0.lib;Winmm.lib;user32.lib;gdi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(VK_SDK_PATH)\Lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
+    <PreBuildEvent>
+      <Command>$(USAGI_DIR)\Tools\bin\rake_vs.bat $(Configuration) $(Platform)</Command>
+    </PreBuildEvent>
+    <PostBuildEvent>
+      <Command>call $(USAGI_DIR)\Tools\bin\vs_post_build.bat $(OutputPath) $(Platform) $(Configuration) $(USAGI_DIR)</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -62,8 +77,8 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;_WINDOWS;_CRT_SECURE_NO_WARNINGS;PREVIEW_HOST;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..;$(USAGI_DIR);$(USAGI_DIR)\_includes;$(USAGI_DIR)\Engine\ThirdParty\pthread-w32\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>$(DEFINES);WIN32;_WINDOWS;_CRT_SECURE_NO_WARNINGS;PREVIEW_HOST;PLATFORM_PC;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <ExceptionHandling>false</ExceptionHandling>
@@ -73,17 +88,82 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>user32.lib;gdi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shlwapi.lib;dxguid.lib;dinput8.lib;vulkan-1.lib;xaudio2.lib;opengl32.lib;glu32.lib;xinput9_1_0.lib;Winmm.lib;user32.lib;gdi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(VK_SDK_PATH)\Lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
+    <PreBuildEvent>
+      <Command>$(USAGI_DIR)\Tools\bin\rake_vs.bat $(Configuration) $(Platform)</Command>
+    </PreBuildEvent>
+    <PostBuildEvent>
+      <Command>call $(USAGI_DIR)\Tools\bin\vs_post_build.bat $(OutputPath) $(Platform) $(Configuration) $(USAGI_DIR)</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\IpcProtocol.cpp" />
+    <ClCompile Include="..\PreviewEngineBridge.cpp" />
     <ClCompile Include="..\PreviewHost.cpp" />
     <ClCompile Include="..\main\_win\WinMain.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\IpcProtocol.h" />
+    <ClInclude Include="..\PreviewEngineBridge.h" />
     <ClInclude Include="..\PreviewHost.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\_build\projects\Engine\Audio\Audio.vcxproj">
+      <Project>{2219a034-b5ef-44ff-b7dc-981cb58711b5}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\_build\projects\Engine\Core\Core.vcxproj">
+      <Project>{4f44a822-08d7-424a-8d40-72677d8346a4}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\_build\projects\Engine\Debug\Debug.vcxproj">
+      <Project>{505a7767-c568-4303-8979-116ff110c8ff}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\_build\projects\Engine\Framework\Framework.vcxproj">
+      <Project>{1da383d2-7811-445a-aacc-ca255b994731}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\_build\projects\Engine\Game\Game.vcxproj">
+      <Project>{1da383d2-7811-445a-aacc-ca255b994732}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\_build\projects\Engine\Graphics\Graphics.vcxproj">
+      <Project>{a73a2dde-2075-496c-9770-21395924e08b}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\_build\projects\Engine\GUI\GUI.vcxproj">
+      <Project>{c918f277-3782-4fad-a501-b5f861a1c5c0}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\_build\projects\Engine\HID\HID.vcxproj">
+      <Project>{6c1ffe72-4fe6-4890-a961-425cac514f62}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\_build\projects\Engine\Layout\Layout.vcxproj">
+      <Project>{f9b13ed7-9cf4-4151-9cb4-3b7edbae1566}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\_build\projects\Engine\Maths\Maths.vcxproj">
+      <Project>{258c9d89-38fb-4b1e-81e1-6d32ac81ff17}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\_build\projects\Engine\Memory\Memory.vcxproj">
+      <Project>{1c319d5b-0060-4653-9000-2ed6c92acaef}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\_build\projects\Engine\Network\Network.vcxproj">
+      <Project>{f68e2bf2-e65e-422f-bbed-249e476331a0}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\_build\projects\Engine\Particles\Particles.vcxproj">
+      <Project>{10466b50-9371-4f53-815b-a024dd74c7e7}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\_build\projects\Engine\PostFX\PostFX.vcxproj">
+      <Project>{be5cb977-8776-4efb-a718-766cf0026e4d}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\_build\projects\Engine\Resource\Resource.vcxproj">
+      <Project>{8e6b74e5-b0c4-4ac1-8e09-7c97747b3f2e}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\_build\projects\Engine\Scene\Scene.vcxproj">
+      <Project>{6febd175-576b-411d-8173-2833305ae882}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\_build\projects\Engine\System\System.vcxproj">
+      <Project>{2ca5c758-fa4d-431a-86ef-79065e243d3e}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\_build\projects\Engine\ThirdParty\ThirdParty.vcxproj">
+      <Project>{491fe2ef-d449-4fdd-a3ce-9a1102aa2af4}</Project>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/Tools/Source/UsagiPreviewHost/project/UsagiPreviewHost.vcxproj.filters
+++ b/Tools/Source/UsagiPreviewHost/project/UsagiPreviewHost.vcxproj.filters
@@ -15,6 +15,9 @@
     <ClCompile Include="..\IpcProtocol.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\PreviewEngineBridge.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\PreviewHost.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -24,6 +27,9 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\IpcProtocol.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\PreviewEngineBridge.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\PreviewHost.h">

--- a/Tools/Tests/PreviewHost/Run.ps1
+++ b/Tools/Tests/PreviewHost/Run.ps1
@@ -3,11 +3,36 @@ param(
     [string]$Configuration = "Debug",
     [ValidateSet("x64")]
     [string]$Platform = "x64",
-    [int]$TimeoutSeconds = 15,
-    [switch]$SkipBuild
+    [int]$TimeoutSeconds = 20,
+    [switch]$SkipBuild,
+    [switch]$SkipAssetLoads
 )
 
 $ErrorActionPreference = "Stop"
+
+if ([Threading.Thread]::CurrentThread.GetApartmentState() -ne [Threading.ApartmentState]::STA) {
+    $powershell = (Get-Command powershell.exe).Source
+    $args = @(
+        "-STA",
+        "-NoProfile",
+        "-ExecutionPolicy", "Bypass",
+        "-File", $PSCommandPath,
+        "-Configuration", $Configuration,
+        "-Platform", $Platform,
+        "-TimeoutSeconds", $TimeoutSeconds
+    )
+
+    if ($SkipBuild) {
+        $args += "-SkipBuild"
+    }
+
+    if ($SkipAssetLoads) {
+        $args += "-SkipAssetLoads"
+    }
+
+    & $powershell @args
+    exit $LASTEXITCODE
+}
 
 function Get-RepoRoot {
     $root = (Resolve-Path $PSScriptRoot).Path
@@ -62,6 +87,8 @@ function Wait-ForLine {
     $readTask = $null
 
     while ([DateTime]::UtcNow -lt $deadline) {
+        [System.Windows.Forms.Application]::DoEvents()
+
         if ($null -eq $readTask) {
             $readTask = $Process.StandardOutput.ReadLineAsync()
         }
@@ -97,11 +124,64 @@ function Wait-ForLine {
     throw "Timed out waiting for $Description. $exitDetails`nstdout:`n$($seen -join "`n")`nstderr:`n$stderr"
 }
 
+function Copy-PreviewResource([string]$RelativePath) {
+    $source = Join-Path $repoRoot "Data\$RelativePath"
+    if (!(Test-Path $source)) {
+        return
+    }
+
+    $destination = Join-Path $romfilesPath $RelativePath
+    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $destination) | Out-Null
+    Copy-Item -LiteralPath $source -Destination $destination -Recurse -Force
+}
+
+function Ensure-PreviewModelResource {
+    $modelPath = Join-Path $romfilesPath "Models\PBRSample\PBRSample.vmdf"
+    if (Test-Path $modelPath) {
+        return
+    }
+
+    $ayataka = Join-Path $repoRoot "Tools\bin\Ayataka.exe"
+    if (!(Test-Path $ayataka)) {
+        throw "Preview smoke requires Ayataka.exe to build the model fixture: $ayataka"
+    }
+
+    $modelSource = Join-Path $repoRoot "Data\Models\PBRSample\PBRSample.fbx"
+    if (!(Test-Path $modelSource)) {
+        throw "Preview smoke requires model source fixture: $modelSource"
+    }
+
+    $modelOutDir = Split-Path -Parent $modelPath
+    $skeletonPath = Join-Path $repoRoot "_build\skel\PBRSample\PBRSample.vmdf.xml"
+    New-Item -ItemType Directory -Force -Path $modelOutDir, (Split-Path -Parent $skeletonPath) | Out-Null
+
+    & $ayataka `
+        "-a16" `
+        "-o$modelPath" `
+        "-sk$modelOutDir\" `
+        "-lh" `
+        "-d$modelPath.d" `
+        "-h$skeletonPath" `
+        $modelSource
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+
+    if (!(Test-Path $modelPath)) {
+        throw "Ayataka did not produce the preview model fixture: $modelPath"
+    }
+}
+
 $repoRoot = Get-RepoRoot
 $env:USAGI_DIR = $repoRoot
 
 $projectPath = Join-Path $repoRoot "Tools\Source\UsagiPreviewHost\project\UsagiPreviewHost.vcxproj"
 $hostPath = Join-Path $repoRoot "Tools\bin\UsagiPreviewHost.exe"
+$generatedProjects = Join-Path $repoRoot "_build\projects"
+
+if (!$SkipBuild -and !(Test-Path $generatedProjects)) {
+    throw "Preview host build requires generated native projects at $generatedProjects. Run project generation first."
+}
 
 if (!$SkipBuild) {
     $msbuild = Get-MSBuild
@@ -115,9 +195,34 @@ if (!(Test-Path $hostPath)) {
     throw "Preview host executable was not found: $hostPath"
 }
 
+Add-Type -AssemblyName System.Windows.Forms
+
+$form = New-Object System.Windows.Forms.Form
+$form.Text = "Usagi Preview Host Smoke"
+$form.Width = 640
+$form.Height = 480
+$form.Show()
+[System.Windows.Forms.Application]::DoEvents()
+
+$romfilesPath = Join-Path $repoRoot "_romfiles\win"
+New-Item -ItemType Directory -Force -Path $romfilesPath | Out-Null
+
+$nameDataHash = Join-Path $romfilesPath "nameDataHash.bin"
+if (!(Test-Path $nameDataHash)) {
+    throw "Preview smoke requires nameDataHash.bin at $nameDataHash. Run a data build first."
+}
+
+if (!$SkipAssetLoads) {
+    Copy-PreviewResource "Particle"
+    Copy-PreviewResource "Effects"
+    Copy-PreviewResource "Textures"
+    Copy-PreviewResource "Models\PBRSample"
+    Ensure-PreviewModelResource
+}
+
 $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
 $startInfo.FileName = $hostPath
-$startInfo.WorkingDirectory = $repoRoot
+$startInfo.WorkingDirectory = $romfilesPath
 $startInfo.UseShellExecute = $false
 $startInfo.CreateNoWindow = $true
 $startInfo.RedirectStandardInput = $true
@@ -134,15 +239,34 @@ try {
     [void](Wait-ForLine $process { param($line) $line -match '"type":"error"' -and $line -match 'not been initialized' } "pre-init protocol error" $TimeoutSeconds)
 
     $dataPath = (Join-Path $repoRoot "Data").Replace("\", "\\")
-    $romfilesPath = (Join-Path $repoRoot "_romfiles\win").Replace("\", "\\")
-    Send-Json $process "{`"type`":`"init`",`"protocolVersion`":1,`"dataPath`":`"$dataPath`",`"romfilesPath`":`"$romfilesPath`"}"
+    $escapedRomfilesPath = $romfilesPath.Replace("\", "\\")
+    Send-Json $process "{`"type`":`"init`",`"protocolVersion`":1,`"dataPath`":`"$dataPath`",`"romfilesPath`":`"$escapedRomfilesPath`"}"
     [void](Wait-ForLine $process { param($line) $line -match '"type":"ready"' -and $line -match '"protocolVersion":1' } "ready response" $TimeoutSeconds)
 
-    Send-Json $process '{"type":"loadEntity","path":"Data/Entities/PreviewSmoke.yml"}'
-    [void](Wait-ForLine $process { param($line) $line -match '"type":"loaded"' -and $line -match '"resourceType":"entity"' -and $line -match '"success":false' } "stub entity load response" $TimeoutSeconds)
+    $hwnd = $form.Handle.ToInt64()
+    Send-Json $process "{`"type`":`"attachWindow`",`"hwnd`":$hwnd,`"width`":640,`"height`":480}"
+    [void](Wait-ForLine $process { param($line) $line -match 'Usagi engine initialized for preview host' } "engine initialization diagnostic" $TimeoutSeconds)
 
-    Send-Json $process '{"type":"loadParticle","emitterPath":"Data/Particle/Emitters/PreviewSmoke.yml","effectPath":null}'
-    [void](Wait-ForLine $process { param($line) $line -match '"type":"loaded"' -and $line -match '"resourceType":"particle"' -and $line -match '"success":false' } "stub particle load response" $TimeoutSeconds)
+    if (!$SkipAssetLoads) {
+        $entityDir = Join-Path $repoRoot "_romfiles\preview"
+        New-Item -ItemType Directory -Force -Path $entityDir | Out-Null
+        $entityPath = Join-Path $entityDir "PreviewPBRSample.yml"
+        @'
+ModelComponent:
+  name: PBRSample/PBRSample.vmdf
+'@ | Set-Content -Encoding ASCII -Path $entityPath
+
+        $escapedEntityPath = $entityPath.Replace("\", "\\")
+        Send-Json $process "{`"type`":`"loadEntity`",`"path`":`"$escapedEntityPath`"}"
+        [void](Wait-ForLine $process { param($line) $line -match '"type":"loaded"' -and $line -match '"resourceType":"entity"' -and $line -match '"success":true' } "successful entity load response" $TimeoutSeconds)
+
+        Send-Json $process '{"type":"loadParticle","emitterPath":"Particle/white_circle.pem","effectPath":null}'
+        [void](Wait-ForLine $process { param($line) $line -match '"type":"loaded"' -and $line -match '"resourceType":"particle"' } "particle load response" $TimeoutSeconds)
+    }
+
+    Send-Json $process '{"type":"tick","deltaTime":0.0166667}'
+    Start-Sleep -Milliseconds 250
+    [System.Windows.Forms.Application]::DoEvents()
 
     Send-Json $process '{"type":"pick","x":4,"y":8}'
     [void](Wait-ForLine $process { param($line) $line -match '"type":"picked"' -and $line -match '"entityId":null' } "empty pick response" $TimeoutSeconds)
@@ -158,7 +282,7 @@ try {
         throw "Preview host exited with code $($process.ExitCode).`nstderr:`n$stderr"
     }
 
-    Write-Host "Preview host headless smoke passed."
+    Write-Host "Preview host asset smoke passed."
 }
 finally {
     if (!$process.HasExited) {
@@ -174,4 +298,6 @@ finally {
     }
 
     $process.Dispose()
+    $form.Close()
+    $form.Dispose()
 }


### PR DESCRIPTION
This adds the native engine bridge behind `UsagiPreviewHost.exe` so the preview
process can initialize the engine, load model/entity and particle resources,
tick the scene, resize the render target, and accept camera commands.

Why this makes sense:

- PR 11 establishes the process and IPC boundary; this is the next reviewable
  preview slice that connects that boundary to engine rendering.
- Model and particle loading are kept inside the native preview host rather
  than mixed with managed editor UI.
- The smoke runner now checks for generated native projects and data-build
  prerequisites explicitly before attempting the heavier preview path.

What changed:

- Added `PreviewEngineBridge` with engine initialization, scene setup, offscreen
  post-FX rendering, basic lighting, tick, resize, camera, shutdown, model load,
  entity YAML model lookup, and particle emitter/effect load support.
- Wired `loadEntity`, `loadParticle`, `tick`, and `setCameraPosition` IPC
  commands through the bridge.
- Updated the preview host Visual Studio project to reference generated engine
  projects and platform libraries needed by the bridge.
- Expanded `Tools/Tests/PreviewHost/Run.ps1` into a repo-relative STA smoke
  runner that embeds the host in a WinForms window and performs entity/model and
  particle load checks when prerequisites are available.
- Did not add managed preview UI or change engine resource/pak runtime code
  outside the preview host.

Validation:

- `git diff --check`
- `powershell -NoProfile -ExecutionPolicy Bypass -File Tools/Tests/PreviewHost/Run.ps1` was run and is blocked by missing generated native projects at `_build\projects`; the runner reports that prerequisite explicitly.
- Feasibility review found and this branch fixes the current `ScriptEmitter::SetInstanceData` signature requirement by passing an explicit zero event CRC for preview-only emitter instances.