### PR TITLE
Add rendering validation for culling and color paths

### DIFF
--- a/Documents/RenderingColorSpacePolicy.md
+++ b/Documents/RenderingColorSpacePolicy.md
@@ -1,0 +1,30 @@
+# Rendering Color Space Policy
+
+This note records the current rendering color-space expectations on the
+v0.3-Development HDR path. It is a validation aid, not a request to change
+swap-chain behavior.
+
+## Policy
+
+- Lighting, material evaluation, bloom, tone mapping, and post effects operate
+  on linear color unless a shader or target explicitly names an encoded output.
+- Albedo, UI color, and other authored display-color textures should use sRGB
+  texture formats so sampling decodes them to linear.
+- Normal, roughness, metallic, mask, lookup, depth, ID, and other data textures
+  must stay in linear/data formats.
+- HDR scene and bloom buffers remain linear HDR intermediates.
+- LDR post-process buffers are treated as linear intermediates until a final
+  output conversion shader writes the display-referred representation.
+- Alex's HDR output shaders (`LinearToHDR`, `LinearToST2084`, and
+  `LinearToExtended`) own final HDR/display conversion. Tests in this PR should
+  validate those files and shader packaging without replacing or bypassing the
+  HDR swap-chain path.
+
+## Validation
+
+- `Data/GLSL/shaders/includes/colorspace.inc` should continue to provide the
+  standard sRGB transfer constants for UI/text and other SDR conversion users.
+- `Data/GLSL/effects/PostProcess.yml` should continue to package the HDR output
+  effects used by the current renderer.
+- Rendering tests should prefer package/build smoke checks and small math
+  invariants before touching runtime rendering code.

--- a/Engine/Maths/AABB.h
+++ b/Engine/Maths/AABB.h
@@ -102,11 +102,11 @@ inline bool AABB::IntersectBox(const usg::Sphere& sphere) const
 		uClip |= 1<<3;
 	}
 
-	if (offset.y > m_radii.y) 
+	if (offset.y > radius.y)
 	{
 		uClip |= 1<<4;
 	}
-	else if (offset.y < -m_radii.y)
+	else if (offset.y < -radius.y)
 	{
 		uClip |= 1<<5;
 	}
@@ -138,11 +138,11 @@ inline bool AABB::ContainedInBox(const usg::Sphere& sphere) const
 		uClip |= 1<<3;
 	}
 
-	if (offset.y > m_radii.y) 
+	if (offset.y > radius.y)
 	{
 		uClip |= 1<<4;
 	}
-	else if (offset.y < -m_radii.y)
+	else if (offset.y < -radius.y)
 	{
 		uClip |= 1<<5;
 	}

--- a/Engine/Maths/Vector4f.h
+++ b/Engine/Maths/Vector4f.h
@@ -96,7 +96,7 @@ static const Vector4f V4F_Z_AXIS(0.0f, 0.0f, 1.0f, 0.0f);
 inline Vector4f ScalarVectorMultiply(const Vector4f &inV, float inScalar )
 {
 //	ASSERT(inV.w == 0.0f);
-	return Vector4f(inScalar*inV.x, inScalar*inV.y, inScalar*inV.z, inV.w);
+	return Vector4f(inScalar*inV.x, inScalar*inV.y, inScalar*inV.z, inScalar*inV.w);
 }
 
 inline Vector4f ScalarVectorDivide(const Vector4f &inV, float scalarValue)

--- a/Engine/Scene/Frustum.cpp
+++ b/Engine/Scene/Frustum.cpp
@@ -157,22 +157,20 @@ PlaneClass Frustum::ClassifyBox(const AABB &box) const
 
 bool Frustum::ArePointsInFrustum(const Vector4f* ppvPoints, uint32 uCount) const
 {
-	// For every plane of frustum
-	const Plane*	pPlane = &m_planes[0];
-	uint32 uInside = uCount;
-
-	for(uint32 uPoint=0; uPoint < uCount; uPoint++)
+	for(uint32 planeId = 0; planeId < PLANE_COUNT; planeId++)
 	{
-		uint32 uPointsInView = 0;
-		for (uint32 planeId = 0; planeId < PLANE_COUNT; planeId++, pPlane++)
+		bool bAllPointsBehind = true;
+		for(uint32 uPoint = 0; uPoint < uCount; uPoint++)
 		{
-			PlaneClass eClass =  pPlane->GetPointPlaneClass(ppvPoints[uPoint].v3());
+			PlaneClass eClass = m_planes[planeId].GetPointPlaneClass(ppvPoints[uPoint].v3());
 			if(eClass != PC_BEHIND)
 			{
-				uPointsInView++;
+				bAllPointsBehind = false;
+				break;
 			}
 		}
-		if (uPointsInView == 0)
+
+		if(bAllPointsBehind)
 		{
 			return false;
 		}

--- a/Tools/Tests/FrustumCulling/FrustumCullingTests.cpp
+++ b/Tools/Tests/FrustumCulling/FrustumCullingTests.cpp
@@ -1,0 +1,117 @@
+#include "Engine/Common/Common.h"
+#include "Engine/Scene/Frustum.h"
+
+#include <cstdio>
+#include <cstdlib>
+
+namespace usg
+{
+	MemType g_uDefaultMemType = MEMTYPE_STANDARD;
+
+	namespace mem
+	{
+		void* Alloc(MemType, MemAllocType, memsize uSize, uint32 uAlign, bool)
+		{
+			UNUSED_VAR(uAlign);
+			return new char[uSize];
+		}
+
+		void Free(MemType, void* pData, bool)
+		{
+			delete[] (char*)pData;
+		}
+
+		void Free(void* pData)
+		{
+			delete[] (char*)pData;
+		}
+	}
+}
+
+namespace eastl
+{
+	void AssertionFailure(const char* pExpression)
+	{
+		printf("EASTL ASSERT FAILED: %s\n", pExpression);
+		abort();
+	}
+}
+
+namespace
+{
+	bool Expect(bool condition, const char* szMessage)
+	{
+		if(!condition)
+		{
+			printf("FAILED: %s\n", szMessage);
+			return false;
+		}
+		return true;
+	}
+
+	usg::Frustum CreateCanonicalFrustum()
+	{
+		usg::Frustum frustum;
+		frustum.SetUp(usg::Matrix4x4::Identity());
+		return frustum;
+	}
+
+	bool TestAcceptsMixedPointSets()
+	{
+		usg::Frustum frustum = CreateCanonicalFrustum();
+		const usg::Vector4f points[] =
+		{
+			usg::Vector4f(0.0f, 0.0f, 0.0f, 1.0f),
+			usg::Vector4f(2.0f, 0.0f, 0.0f, 1.0f),
+			usg::Vector4f(0.0f, 0.5f, 0.0f, 1.0f)
+		};
+
+		return Expect(frustum.ArePointsInFrustum(points, ARRAY_SIZE(points)),
+			"point sets stay visible when at least one point survives each frustum plane");
+	}
+
+	bool TestRejectsPointSetsBehindOnePlane()
+	{
+		usg::Frustum frustum = CreateCanonicalFrustum();
+		const usg::Vector4f points[] =
+		{
+			usg::Vector4f(2.0f, -0.5f, 0.0f, 1.0f),
+			usg::Vector4f(2.0f, 0.0f, 0.0f, 1.0f),
+			usg::Vector4f(2.0f, 0.5f, 0.0f, 1.0f)
+		};
+
+		return Expect(!frustum.ArePointsInFrustum(points, ARRAY_SIZE(points)),
+			"point sets cull only when every point is behind the same frustum plane");
+	}
+
+	bool TestAcceptsCanonicalBoxCorners()
+	{
+		usg::Frustum frustum = CreateCanonicalFrustum();
+		const usg::Vector4f points[] =
+		{
+			usg::Vector4f(-0.5f, -0.5f, 0.0f, 1.0f),
+			usg::Vector4f(-0.5f, 0.5f, 0.0f, 1.0f),
+			usg::Vector4f(0.5f, -0.5f, 0.0f, 1.0f),
+			usg::Vector4f(0.5f, 0.5f, 0.0f, 1.0f)
+		};
+
+		return Expect(frustum.ArePointsInFrustum(points, ARRAY_SIZE(points)),
+			"canonical in-frustum corners are visible");
+	}
+}
+
+int main()
+{
+	bool ok = true;
+	ok &= TestAcceptsMixedPointSets();
+	ok &= TestRejectsPointSetsBehindOnePlane();
+	ok &= TestAcceptsCanonicalBoxCorners();
+
+	if(!ok)
+	{
+		return 1;
+	}
+
+	printf("FrustumCulling tests passed\n");
+	return 0;
+}

--- a/Tools/Tests/FrustumCulling/Run.ps1
+++ b/Tools/Tests/FrustumCulling/Run.ps1
@@ -1,0 +1,97 @@
+$ErrorActionPreference = 'Stop'
+
+$TestDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$UsagiRoot = (Resolve-Path (Join-Path $TestDir '..\..\..')).Path
+$ExternalToolsRoot = Join-Path (Split-Path -Parent (Split-Path -Parent $UsagiRoot)) 'tools'
+$EnvScript = Join-Path $ExternalToolsRoot 'usagi-dev-env.ps1'
+
+if (Test-Path $EnvScript) {
+    & { . $EnvScript } *> $null
+}
+
+$env:USAGI_DIR = $UsagiRoot
+
+$GeneratedInclude = Join-Path $UsagiRoot '_build\win\debug'
+if (-not (Test-Path $GeneratedInclude)) {
+    throw "Generated include directory not found: $GeneratedInclude. Run the Usagi build generation step before native tests."
+}
+
+$BuildDir = Join-Path $UsagiRoot 'Tools\test-build\FrustumCulling'
+New-Item -ItemType Directory -Force -Path $BuildDir | Out-Null
+
+$Source = Join-Path $TestDir 'FrustumCullingTests.cpp'
+$Exe = Join-Path $BuildDir 'FrustumCullingTests.exe'
+
+$VcVarsCandidates = @(
+    $env:VCVARS64,
+    'C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat',
+    'C:\Program Files\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat',
+    'C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Auxiliary\Build\vcvars64.bat',
+    'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
+) | Where-Object { $_ -and (Test-Path $_) }
+
+if (-not $VcVarsCandidates) {
+    throw 'Unable to find vcvars64.bat. Install Visual Studio C++ tools or set VCVARS64.'
+}
+
+$Defines = @(
+    '/DPLATFORM_PC',
+    '/D_DEBUG',
+    '/DFINAL_BUILD',
+    '/DVK_USE_PLATFORM_WIN32_KHR',
+    '/D"LUA_USER_H=<Engine/Framework/Script/LuaConf.h>"',
+    '/DPB_FIELD_32BIT',
+    '/DNN_SWITCH_ENABLE_HOST_IO',
+    '/DEASTL_USER_DEFINED_ALLOCATOR',
+    '/DEASTL_CUSTOM_FLOAT_CONSTANTS_REQUIRED=1',
+    '/D_CRT_SECURE_NO_WARNINGS'
+)
+
+$Includes = @(
+    "/I$UsagiRoot",
+    "/I$GeneratedInclude",
+    "/I$UsagiRoot\Engine\ThirdParty\nanopb",
+    "/I$UsagiRoot\Engine\ThirdParty\EASTL\include",
+    "/I$UsagiRoot\Engine\ThirdParty\EASTL\test\packages\EABase\include\Common",
+    "/I$UsagiRoot\Engine\ThirdParty\lua-5.3.2\src",
+    "/I$UsagiRoot\Engine\ThirdParty\yaml-cpp\include",
+    "/I$UsagiRoot\Engine\ThirdParty\gli",
+    "/I$UsagiRoot\Engine\ThirdParty\gli\external",
+    "/I$env:VK_SDK_PATH\Include"
+)
+
+$Sources = @(
+    $Source,
+    (Join-Path $UsagiRoot 'Engine\Scene\Frustum.cpp'),
+    (Join-Path $UsagiRoot 'Engine\Maths\AABB.cpp'),
+    (Join-Path $UsagiRoot 'Engine\Maths\MathUtil.cpp'),
+    (Join-Path $UsagiRoot 'Engine\Maths\Matrix3x3.cpp'),
+    (Join-Path $UsagiRoot 'Engine\Maths\Matrix4x3.cpp'),
+    (Join-Path $UsagiRoot 'Engine\Maths\Matrix4x4.cpp'),
+    (Join-Path $UsagiRoot 'Engine\Maths\Plane.cpp'),
+    (Join-Path $UsagiRoot 'Engine\Maths\Quaternionf.cpp'),
+    (Join-Path $UsagiRoot 'Engine\Maths\Sphere.cpp'),
+    (Join-Path $UsagiRoot 'Engine\Maths\Vector2f.cpp'),
+    (Join-Path $UsagiRoot 'Engine\Maths\Vector3f.cpp'),
+    (Join-Path $UsagiRoot 'Engine\Maths\Vector4f.cpp'),
+    (Join-Path $UsagiRoot 'Engine\Maths\_vulkan\Matrix4x4_ps.cpp'),
+    (Join-Path $UsagiRoot 'Engine\Core\Timer\_win\TimeTracker.cpp')
+)
+
+$CommandParts = @(
+    "`"$($VcVarsCandidates[0])`" >nul &&",
+    'cl /nologo /std:c++17 /EHsc /MTd /Zi /wd4291'
+) + $Defines + $Includes + @(
+    "/Fo$BuildDir\",
+    "/Fe$Exe"
+) + $Sources
+
+cmd /c ($CommandParts -join ' ')
+if ($LASTEXITCODE -ne 0) {
+    throw "Frustum culling test build failed with exit code $LASTEXITCODE"
+}
+
+& $Exe
+if ($LASTEXITCODE -ne 0) {
+    throw "Frustum culling test executable failed with exit code $LASTEXITCODE"
+}

--- a/Tools/Tests/GammaOutput/Run.ps1
+++ b/Tools/Tests/GammaOutput/Run.ps1
@@ -1,0 +1,111 @@
+$ErrorActionPreference = 'Stop'
+
+$TestDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$UsagiRoot = (Resolve-Path (Join-Path $TestDir '..\..\..')).Path
+$BuildDir = Join-Path $UsagiRoot 'Tools\test-build\GammaOutput'
+$PackageDir = Join-Path $BuildDir 'packages'
+$TempDir = Join-Path $BuildDir 'tmp'
+$Ramp = Join-Path $BuildDir 'srgb_expected.ppm'
+New-Item -ItemType Directory -Force -Path $BuildDir, $PackageDir, $TempDir | Out-Null
+
+function Read-RequiredText($Path) {
+    if (-not (Test-Path $Path)) {
+        throw "Required file not found: $Path"
+    }
+    Get-Content -Raw -Path $Path
+}
+
+function Convert-LinearToSrgbByte([double]$Value) {
+    $Value = [Math]::Max($Value, 0.0)
+    if ($Value -le 0.0031308) {
+        $Srgb = $Value * 12.92
+    } else {
+        $Srgb = (1.055 * [Math]::Pow($Value, 1.0 / 2.4)) - 0.055
+    }
+    $Srgb = [Math]::Min([Math]::Max($Srgb, 0.0), 1.0)
+    [byte][Math]::Floor(($Srgb * 255.0) + 0.5)
+}
+
+function Assert-Byte($Name, [double]$Linear, [byte]$Expected) {
+    $Actual = Convert-LinearToSrgbByte $Linear
+    if ($Actual -ne $Expected) {
+        throw "$Name expected $Expected, got $Actual"
+    }
+}
+
+$ColorSpace = Read-RequiredText (Join-Path $UsagiRoot 'Data\GLSL\shaders\includes\colorspace.inc')
+$PostProcess = Read-RequiredText (Join-Path $UsagiRoot 'Data\GLSL\effects\PostProcess.yml')
+$LinearToHDR = Read-RequiredText (Join-Path $UsagiRoot 'Data\GLSL\shaders\PostFX\LinearToHDR.frag')
+$LinearToST2084 = Read-RequiredText (Join-Path $UsagiRoot 'Data\GLSL\shaders\PostFX\LinearToST2084.frag')
+
+foreach ($Needle in @('0.0031308', '12.92', '1.0/2.4', '0.04045', '2.4')) {
+    if (-not $ColorSpace.Contains($Needle)) {
+        throw "colorspace.inc no longer contains expected sRGB transfer token: $Needle"
+    }
+}
+
+foreach ($Needle in @('LinearToHDR', 'LinearToST2084', 'LinearToExtended')) {
+    if (-not $PostProcess.Contains($Needle)) {
+        throw "PostProcess.yml no longer packages HDR output effect: $Needle"
+    }
+}
+
+foreach ($Needle in @('InverseTonemap', 'Hdr10', 'LinearToST2084')) {
+    if (-not $LinearToHDR.Contains($Needle)) {
+        throw "LinearToHDR.frag no longer contains expected HDR conversion token: $Needle"
+    }
+}
+
+foreach ($Needle in @('k709to2020', 'kExpanded709to2020', 'LinearToST2084')) {
+    if (-not $LinearToST2084.Contains($Needle)) {
+        throw "LinearToST2084.frag no longer contains expected HDR10 token: $Needle"
+    }
+}
+
+Assert-Byte 'black' -0.25 0
+Assert-Byte 'linear zero' 0.0 0
+Assert-Byte 'srgb toe boundary' 0.0031308 10
+Assert-Byte 'middle gray' 0.18 118
+Assert-Byte 'half linear' 0.5 188
+Assert-Byte 'white' 1.0 255
+
+$Last = 0
+for ($X = 0; $X -lt 256; $X++) {
+    $Current = Convert-LinearToSrgbByte ([double]$X / 255.0)
+    if (($X -gt 0) -and ($Current -lt $Last)) {
+        throw "sRGB ramp is not monotonic at $X"
+    }
+    $Last = $Current
+}
+
+$Header = [Text.Encoding]::ASCII.GetBytes("P6`n256 16`n255`n")
+$Pixels = New-Object byte[] (256 * 16 * 3)
+$Index = 0
+for ($Y = 0; $Y -lt 16; $Y++) {
+    for ($X = 0; $X -lt 256; $X++) {
+        $Byte = Convert-LinearToSrgbByte ([double]$X / 255.0)
+        $Pixels[$Index++] = $Byte
+        $Pixels[$Index++] = $Byte
+        $Pixels[$Index++] = $Byte
+    }
+}
+[IO.File]::WriteAllBytes($Ramp, $Header + $Pixels)
+
+$ShaderPackage = Join-Path $UsagiRoot 'Tools\bin\ShaderPackage.exe'
+$PostProcessEffect = Join-Path $UsagiRoot 'Data\GLSL\effects\PostProcess.yml'
+$ShaderDir = Join-Path $UsagiRoot 'Data\GLSL\shaders'
+$PostProcessPackage = Join-Path $PackageDir 'PostProcess.pak'
+
+if (-not (Test-Path $ShaderPackage)) {
+    throw "ShaderPackage.exe not found: $ShaderPackage"
+}
+
+& $ShaderPackage "-avulkan" "-o$PostProcessPackage" "-t$TempDir" "-s$ShaderDir" $PostProcessEffect
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}
+if (-not (Test-Path $PostProcessPackage)) {
+    throw "Shader package was not produced: $PostProcessPackage"
+}
+
+Write-Host 'Gamma output smoke test passed'

--- a/Tools/Tests/Maths/MathsTests.cpp
+++ b/Tools/Tests/Maths/MathsTests.cpp
@@ -1,0 +1,231 @@
+#include "Engine/Common/Common.h"
+#include "Engine/Maths/AABB.h"
+#include "Engine/Maths/Matrix4x4.h"
+#include "Engine/Maths/Quaternionf.h"
+#include "Engine/Maths/Sphere.h"
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+
+namespace usg
+{
+	MemType g_uDefaultMemType = MEMTYPE_STANDARD;
+
+	namespace mem
+	{
+		void* Alloc(MemType, MemAllocType, memsize uSize, uint32 uAlign, bool)
+		{
+			UNUSED_VAR(uAlign);
+			return new char[uSize];
+		}
+
+		void Free(MemType, void* pData, bool)
+		{
+			delete[] (char*)pData;
+		}
+
+		void Free(void* pData)
+		{
+			delete[] (char*)pData;
+		}
+	}
+}
+
+namespace eastl
+{
+	void AssertionFailure(const char* pExpression)
+	{
+		printf("EASTL ASSERT FAILED: %s\n", pExpression);
+		abort();
+	}
+}
+
+namespace
+{
+	bool Expect(bool condition, const char* szMessage)
+	{
+		if(!condition)
+		{
+			printf("FAILED: %s\n", szMessage);
+			return false;
+		}
+		return true;
+	}
+
+	bool NearlyEqual(float a, float b, float epsilon = 1e-4f)
+	{
+		return fabsf(a - b) <= epsilon;
+	}
+
+	bool ExpectVector(const usg::Vector3f& value, const usg::Vector3f& expected, const char* szMessage)
+	{
+		const bool ok = NearlyEqual(value.x, expected.x) && NearlyEqual(value.y, expected.y) && NearlyEqual(value.z, expected.z);
+		if(!ok)
+		{
+			printf("FAILED: %s got=(%.6f, %.6f, %.6f) expected=(%.6f, %.6f, %.6f)\n",
+				szMessage, value.x, value.y, value.z, expected.x, expected.y, expected.z);
+		}
+		return ok;
+	}
+
+	bool ExpectVector4(const usg::Vector4f& value, const usg::Vector4f& expected, const char* szMessage)
+	{
+		const bool ok = NearlyEqual(value.x, expected.x) && NearlyEqual(value.y, expected.y) &&
+			NearlyEqual(value.z, expected.z) && NearlyEqual(value.w, expected.w);
+		if(!ok)
+		{
+			printf("FAILED: %s got=(%.6f, %.6f, %.6f, %.6f) expected=(%.6f, %.6f, %.6f, %.6f)\n",
+				szMessage, value.x, value.y, value.z, value.w, expected.x, expected.y, expected.z, expected.w);
+		}
+		return ok;
+	}
+
+	bool TestMatrixTranslationUsesVectorW()
+	{
+		usg::Matrix4x4 transform = usg::Matrix4x4::Identity();
+		transform.SetTranslation(2.0f, -3.0f, 5.0f);
+
+		bool ok = true;
+		ok &= ExpectVector(transform.TransformVec3(usg::Vector3f(1.0f, 2.0f, 3.0f), 1.0f),
+			usg::Vector3f(3.0f, -1.0f, 8.0f), "position transform applies translation");
+		ok &= ExpectVector(transform.TransformVec3(usg::Vector3f(1.0f, 2.0f, 3.0f), 0.0f),
+			usg::Vector3f(1.0f, 2.0f, 3.0f), "direction transform ignores translation");
+		return ok;
+	}
+
+	bool TestAABBContainmentAndLerp()
+	{
+		usg::AABB box;
+		box.SetCentreRadii(usg::Vector3f(0.0f, 0.0f, 0.0f), usg::Vector3f(1.0f, 2.0f, 3.0f));
+
+		bool ok = true;
+		ok &= Expect(box.InBox(usg::Vector3f(1.0f, -2.0f, 3.0f)), "AABB includes boundary points");
+		ok &= Expect(!box.InBox(usg::Vector3f(1.1f, 0.0f, 0.0f)), "AABB rejects points outside one axis");
+
+		usg::AABB start(usg::Vector3f(-1.0f, -1.0f, -1.0f), usg::Vector3f(1.0f, 1.0f, 1.0f));
+		usg::AABB end(usg::Vector3f(1.0f, 3.0f, 5.0f), usg::Vector3f(5.0f, 7.0f, 9.0f));
+		usg::AABB midpoint;
+		usg::Lerp(start, end, midpoint, 0.5f);
+
+		usg::Vector3f centre;
+		usg::Vector3f radii;
+		midpoint.GetCentreRadii(centre, radii);
+		ok &= ExpectVector(centre, usg::Vector3f(1.5f, 2.5f, 3.5f), "AABB lerp interpolates centre");
+		ok &= ExpectVector(radii, usg::Vector3f(1.5f, 1.5f, 1.5f), "AABB lerp interpolates radii");
+		return ok;
+	}
+
+	bool TestVector4LerpInterpolatesW()
+	{
+		const usg::Vector4f start(0.0f, 2.0f, 4.0f, 0.0f);
+		const usg::Vector4f end(10.0f, 12.0f, 14.0f, 1.0f);
+		const usg::Vector4f expected(5.0f, 7.0f, 9.0f, 0.5f);
+
+		bool ok = true;
+		ok &= ExpectVector4(usg::Lerp(start, end, 0.5f), expected, "Vector4f Lerp return overload interpolates w");
+
+		usg::Vector4f out;
+		usg::Lerp(start, end, out, 0.5f);
+		ok &= ExpectVector4(out, expected, "Vector4f Lerp out-param overload interpolates w");
+		return ok;
+	}
+
+	bool TestScalarWrapHelpers()
+	{
+		bool ok = true;
+		ok &= Expect(NearlyEqual(usg::Math::WrapValue(370.0f, 0.0f, 360.0f), 10.0f),
+			"WrapValue wraps values above range");
+		ok &= Expect(NearlyEqual(usg::Math::WrapValue(-10.0f, 0.0f, 360.0f), 350.0f),
+			"WrapValue wraps values below range");
+		ok &= Expect(NearlyEqual(usg::Math::MatchLoopingValue(5.0f, 355.0f, 0.0f, 360.0f), 365.0f),
+			"MatchLoopingValue moves low value near high match");
+		ok &= Expect(NearlyEqual(usg::Math::MatchLoopingValue(355.0f, 5.0f, 0.0f, 360.0f), -5.0f),
+			"MatchLoopingValue moves high value near low match");
+		return ok;
+	}
+
+	bool TestHermiteEndpoints()
+	{
+		const usg::Vector3f p0(1.0f, 2.0f, 3.0f);
+		const usg::Vector3f v0(4.0f, 5.0f, 6.0f);
+		const usg::Vector3f p1(7.0f, 8.0f, 9.0f);
+		const usg::Vector3f v1(-1.0f, -2.0f, -3.0f);
+
+		bool ok = true;
+		ok &= ExpectVector(usg::Math::Hermite(p0, v0, p1, v1, 0.0f), p0, "Hermite returns p0 at t=0");
+		ok &= ExpectVector(usg::Math::Hermite(p0, v0, p1, v1, 1.0f), p1, "Hermite returns p1 at t=1");
+		ok &= ExpectVector(usg::Math::HermiteDerivative(p0, v0, p1, v1, 0.0f), v0, "HermiteDerivative returns v0 at t=0");
+		ok &= ExpectVector(usg::Math::HermiteDerivative(p0, v0, p1, v1, 1.0f), v1, "HermiteDerivative returns v1 at t=1");
+		return ok;
+	}
+
+	bool TestAABBPointAccumulation()
+	{
+		usg::AABB box;
+		box.Invalidate();
+		box.Apply(usg::Vector3f(-1.0f, 2.0f, 0.5f));
+		box.Apply(usg::Vector3f(3.0f, -2.0f, 4.0f));
+
+		usg::Vector3f centre;
+		usg::Vector3f radii;
+		box.GetCentreRadii(centre, radii);
+
+		bool ok = true;
+		ok &= ExpectVector(box.GetMin(), usg::Vector3f(-1.0f, -2.0f, 0.5f), "AABB Apply tracks minimum point");
+		ok &= ExpectVector(box.GetMax(), usg::Vector3f(3.0f, 2.0f, 4.0f), "AABB Apply tracks maximum point");
+		ok &= ExpectVector(centre, usg::Vector3f(1.0f, 0.0f, 2.25f), "AABB Apply updates centre");
+		ok &= ExpectVector(radii, usg::Vector3f(2.0f, 2.0f, 1.75f), "AABB Apply updates radii");
+		return ok;
+	}
+
+	bool TestSphereIntersectionBoundary()
+	{
+		const usg::Sphere origin(usg::Vector3f(0.0f, 0.0f, 0.0f), 2.0f);
+
+		bool ok = true;
+		ok &= Expect(origin.Intersect(usg::Sphere(usg::Vector3f(3.0f, 0.0f, 0.0f), 1.0f)),
+			"Sphere intersection includes tangent boundary");
+		ok &= Expect(!origin.Intersect(usg::Sphere(usg::Vector3f(3.01f, 0.0f, 0.0f), 1.0f)),
+			"Sphere intersection rejects separated spheres");
+		return ok;
+	}
+
+	bool TestAABBSphereYRadiusBoundaries()
+	{
+		usg::AABB box;
+		box.SetCentreRadii(usg::Vector3f(0.0f, 0.0f, 0.0f), usg::Vector3f(1.0f, 1.0f, 1.0f));
+
+		bool ok = true;
+		ok &= Expect(box.IntersectBox(usg::Sphere(usg::Vector3f(0.0f, 1.5f, 0.0f), 0.5f)),
+			"AABB sphere intersection expands Y bounds by sphere radius");
+		ok &= Expect(!box.IntersectBox(usg::Sphere(usg::Vector3f(0.0f, 1.6f, 0.0f), 0.5f)),
+			"AABB sphere intersection rejects Y separation beyond radius");
+		ok &= Expect(box.ContainedInBox(usg::Sphere(usg::Vector3f(0.0f, 0.5f, 0.0f), 0.5f)),
+			"AABB sphere containment shrinks Y bounds by sphere radius");
+		ok &= Expect(!box.ContainedInBox(usg::Sphere(usg::Vector3f(0.0f, 0.6f, 0.0f), 0.5f)),
+			"AABB sphere containment rejects Y overlap outside shrunken bounds");
+		return ok;
+	}
+}
+
+int main()
+{
+	bool ok = true;
+	ok &= TestMatrixTranslationUsesVectorW();
+	ok &= TestAABBContainmentAndLerp();
+	ok &= TestVector4LerpInterpolatesW();
+	ok &= TestScalarWrapHelpers();
+	ok &= TestHermiteEndpoints();
+	ok &= TestAABBPointAccumulation();
+	ok &= TestSphereIntersectionBoundary();
+	ok &= TestAABBSphereYRadiusBoundaries();
+
+	if(!ok)
+	{
+		return 1;
+	}
+
+	printf("Maths tests passed\n");
+	return 0;
+}

--- a/Tools/Tests/Maths/Run.ps1
+++ b/Tools/Tests/Maths/Run.ps1
@@ -1,0 +1,96 @@
+$ErrorActionPreference = 'Stop'
+
+$TestDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$UsagiRoot = (Resolve-Path (Join-Path $TestDir '..\..\..')).Path
+$ExternalToolsRoot = Join-Path (Split-Path -Parent (Split-Path -Parent $UsagiRoot)) 'tools'
+$EnvScript = Join-Path $ExternalToolsRoot 'usagi-dev-env.ps1'
+
+if (Test-Path $EnvScript) {
+    & { . $EnvScript } *> $null
+}
+
+$env:USAGI_DIR = $UsagiRoot
+
+$GeneratedInclude = Join-Path $UsagiRoot '_build\win\debug'
+if (-not (Test-Path $GeneratedInclude)) {
+    throw "Generated include directory not found: $GeneratedInclude. Run the Usagi build generation step before native tests."
+}
+
+$BuildDir = Join-Path $UsagiRoot 'Tools\test-build\Maths'
+New-Item -ItemType Directory -Force -Path $BuildDir | Out-Null
+
+$Source = Join-Path $TestDir 'MathsTests.cpp'
+$Exe = Join-Path $BuildDir 'MathsTests.exe'
+
+$VcVarsCandidates = @(
+    $env:VCVARS64,
+    'C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat',
+    'C:\Program Files\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat',
+    'C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Auxiliary\Build\vcvars64.bat',
+    'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
+) | Where-Object { $_ -and (Test-Path $_) }
+
+if (-not $VcVarsCandidates) {
+    throw 'Unable to find vcvars64.bat. Install Visual Studio C++ tools or set VCVARS64.'
+}
+
+$Defines = @(
+    '/DPLATFORM_PC',
+    '/D_DEBUG',
+    '/DFINAL_BUILD',
+    '/DVK_USE_PLATFORM_WIN32_KHR',
+    '/D"LUA_USER_H=<Engine/Framework/Script/LuaConf.h>"',
+    '/DPB_FIELD_32BIT',
+    '/DNN_SWITCH_ENABLE_HOST_IO',
+    '/DEASTL_USER_DEFINED_ALLOCATOR',
+    '/DEASTL_CUSTOM_FLOAT_CONSTANTS_REQUIRED=1',
+    '/D_CRT_SECURE_NO_WARNINGS'
+)
+
+$Includes = @(
+    "/I$UsagiRoot",
+    "/I$GeneratedInclude",
+    "/I$UsagiRoot\Engine\ThirdParty\nanopb",
+    "/I$UsagiRoot\Engine\ThirdParty\EASTL\include",
+    "/I$UsagiRoot\Engine\ThirdParty\EASTL\test\packages\EABase\include\Common",
+    "/I$UsagiRoot\Engine\ThirdParty\lua-5.3.2\src",
+    "/I$UsagiRoot\Engine\ThirdParty\yaml-cpp\include",
+    "/I$UsagiRoot\Engine\ThirdParty\gli",
+    "/I$UsagiRoot\Engine\ThirdParty\gli\external",
+    "/I$env:VK_SDK_PATH\Include"
+)
+
+$Sources = @(
+    $Source,
+    (Join-Path $UsagiRoot 'Engine\Maths\AABB.cpp'),
+    (Join-Path $UsagiRoot 'Engine\Maths\MathUtil.cpp'),
+    (Join-Path $UsagiRoot 'Engine\Maths\Matrix3x3.cpp'),
+    (Join-Path $UsagiRoot 'Engine\Maths\Matrix4x3.cpp'),
+    (Join-Path $UsagiRoot 'Engine\Maths\Matrix4x4.cpp'),
+    (Join-Path $UsagiRoot 'Engine\Maths\Plane.cpp'),
+    (Join-Path $UsagiRoot 'Engine\Maths\Quaternionf.cpp'),
+    (Join-Path $UsagiRoot 'Engine\Maths\Sphere.cpp'),
+    (Join-Path $UsagiRoot 'Engine\Maths\Vector2f.cpp'),
+    (Join-Path $UsagiRoot 'Engine\Maths\Vector3f.cpp'),
+    (Join-Path $UsagiRoot 'Engine\Maths\Vector4f.cpp'),
+    (Join-Path $UsagiRoot 'Engine\Maths\_vulkan\Matrix4x4_ps.cpp'),
+    (Join-Path $UsagiRoot 'Engine\Core\Timer\_win\TimeTracker.cpp')
+)
+
+$CommandParts = @(
+    "`"$($VcVarsCandidates[0])`" >nul &&",
+    'cl /nologo /std:c++17 /EHsc /MTd /Zi /wd4291'
+) + $Defines + $Includes + @(
+    "/Fo$BuildDir\",
+    "/Fe$Exe"
+) + $Sources
+
+cmd /c ($CommandParts -join ' ')
+if ($LASTEXITCODE -ne 0) {
+    throw "Maths test build failed with exit code $LASTEXITCODE"
+}
+
+& $Exe
+if ($LASTEXITCODE -ne 0) {
+    throw "Maths test executable failed with exit code $LASTEXITCODE"
+}

--- a/Tools/Tests/ShaderPackageRendering/Run.ps1
+++ b/Tools/Tests/ShaderPackageRendering/Run.ps1
@@ -1,0 +1,37 @@
+$ErrorActionPreference = 'Stop'
+
+$TestDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$UsagiRoot = (Resolve-Path (Join-Path $TestDir '..\..\..')).Path
+$BuildDir = Join-Path $UsagiRoot 'Tools\test-build\ShaderPackageRendering'
+$PackageDir = Join-Path $BuildDir 'packages'
+$TempDir = Join-Path $BuildDir 'tmp'
+$ShaderDir = Join-Path $UsagiRoot 'Data\GLSL\shaders'
+$ShaderPackage = Join-Path $UsagiRoot 'Tools\bin\ShaderPackage.exe'
+
+if (-not (Test-Path $ShaderPackage)) {
+    throw "ShaderPackage.exe not found: $ShaderPackage"
+}
+
+New-Item -ItemType Directory -Force -Path $PackageDir, $TempDir | Out-Null
+
+$Packages = @(
+    @{ Name = 'Model'; Effect = 'Data\GLSL\effects\Model.yml' },
+    @{ Name = 'PostProcess'; Effect = 'Data\GLSL\effects\PostProcess.yml' },
+    @{ Name = 'Particles'; Effect = 'Data\GLSL\effects\Particles.yml' }
+)
+
+foreach ($Package in $Packages) {
+    $EffectPath = Join-Path $UsagiRoot $Package.Effect
+    $OutputPath = Join-Path $PackageDir "$($Package.Name).pak"
+
+    & $ShaderPackage "-avulkan" "-o$OutputPath" "-t$TempDir" "-s$ShaderDir" $EffectPath
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+
+    if (-not (Test-Path $OutputPath)) {
+        throw "Shader package was not produced: $OutputPath"
+    }
+}
+
+Write-Host 'Rendering shader package smoke test passed'


### PR DESCRIPTION
This adds focused rendering/math validation and carries only the tiny source
fixes needed by those checks, without changing Alex's HDR swap-chain behavior.

Why this makes sense:

- The migration needs confidence around frustum, math, shader packaging, and
  color-space assumptions before larger rendering/model/resource changes.
- The tests preserve useful migration validation intent while treating the
  current HDR path as the baseline.
- The source fixes are narrow correctness issues covered by the new native test
  cases.

What changed:

- Fixed `Frustum::ArePointsInFrustum` so a point set is culled only when every
  point is behind the same frustum plane.
- Fixed AABB/sphere Y-axis radius handling in intersection and containment.
- Fixed `Vector4f` scalar multiply so `w` is scaled, which makes `Vector4f`
  lerp interpolate `w`.
- Added `Tools/Tests/FrustumCulling`, `Tools/Tests/Maths`,
  `Tools/Tests/GammaOutput`, and `Tools/Tests/ShaderPackageRendering`.
- Added `Documents/RenderingColorSpacePolicy.md` as validation guidance for the
  current HDR path.

Validation:

- `powershell -NoProfile -ExecutionPolicy Bypass -File Tools/Tests/GammaOutput/Run.ps1` passed.
- `powershell -NoProfile -ExecutionPolicy Bypass -File Tools/Tests/ShaderPackageRendering/Run.ps1` passed.
- `Tools/Tests/Maths/Run.ps1` and `Tools/Tests/FrustumCulling/Run.ps1` were
  run and are blocked by missing generated includes at `_build\win\debug`; the
  scripts report that build-generation prerequisite explicitly.
- `git diff --check`