### PR TITLE
Validate model instancing baseline

### DIFF
--- a/Documents/ModelInstancing.md
+++ b/Documents/ModelInstancing.md
@@ -1,0 +1,25 @@
+# Model Instancing
+
+`Tools/Tests/ModelInstancing/Run.ps1` is a narrow smoke test for the current
+model instance conversion and renderer baseline. It creates a temporary Usagi
+data root with a minimal entity YAML, converts a tiny `.lvl` through
+`Tools/python/lvl2vhir/lvl2vhir.py`, and verifies the generated instance-set
+YAML contract:
+
+- `Instance: true`
+- `Format: transform`
+- two nodes for the two level objects
+- the current `.vmdc` model resource name emitted by the level converter
+- left-handed converted translations
+
+The test also checks the renderer-side hooks that Alex's branch already has:
+instance model resources declare an instance-rate transform stream, model meshes
+with instancing support create `InstanceMesh` nodes, `ModelInstanceRenderer`
+batches transforms into a vertex buffer, and `InstanceDrawer` submits
+`DrawIndexedEx` with the batched instance count.
+
+The broader porting branch explored a separate explicit `Model::LoadInstanced`
+entry point and `.vmdf` instance-set naming. Those are intentionally not ported
+in this PR because the current branch already has a renderer-level batching
+path, and switching level-converter asset naming should be reviewed separately
+with resource build coverage.

--- a/Tools/Tests/ModelInstancing/Run.ps1
+++ b/Tools/Tests/ModelInstancing/Run.ps1
@@ -1,0 +1,154 @@
+param()
+
+$ErrorActionPreference = "Stop"
+
+function Get-RepoRoot {
+    $root = (Resolve-Path $PSScriptRoot).Path
+    while ($root -and !(Test-Path (Join-Path $root "Engine\CommonProps.props"))) {
+        $parent = Split-Path $root -Parent
+        if ($parent -eq $root) {
+            break
+        }
+
+        $root = $parent
+    }
+
+    if (!$root -or !(Test-Path (Join-Path $root "Engine\CommonProps.props"))) {
+        throw "Could not locate Usagi repository root from $PSScriptRoot"
+    }
+
+    return $root
+}
+
+$RepoRoot = Get-RepoRoot
+$BuildRoot = Join-Path $RepoRoot "Tools\test-build\ModelInstancing"
+$TempRoot = Join-Path $BuildRoot "TempUsagi"
+$OutRoot = Join-Path $BuildRoot "out"
+
+Remove-Item -LiteralPath $BuildRoot -Recurse -Force -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Path $TempRoot, $OutRoot | Out-Null
+New-Item -ItemType Directory -Path (Join-Path $TempRoot "Data\Entities") | Out-Null
+
+@'
+Inherits:
+  - PropBase
+ModelComponent:
+  name: Models/PBRSample/PBRSample
+'@ | Set-Content -Encoding ASCII -Path (Join-Path $TempRoot "Data\Entities\PBRSampleProp.yml")
+
+$LevelPath = Join-Path $BuildRoot "model_instances.lvl"
+@'
+<game xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="gap" name="Game">
+  <gameObjectFolder name="GameObjects" visible="true" locked="false">
+    <folder name="Instances" visible="true" locked="false">
+      <gameObject xsi:type="gameObjectType" name="InstancedModelA" translate="1 2 3" rotate="0 0 0" scale="1 1 1" visible="true">
+        <resource xsi:type="resourceReferenceType" uri="Entities/PBRSampleProp.yml" />
+      </gameObject>
+      <gameObject xsi:type="gameObjectType" name="InstancedModelB" translate="4 5 6" rotate="0 0 0" scale="1 1 1" visible="true">
+        <resource xsi:type="resourceReferenceType" uri="Entities/PBRSampleProp.yml" />
+      </gameObject>
+    </folder>
+  </gameObjectFolder>
+</game>
+'@ | Set-Content -Encoding ASCII -Path $LevelPath
+
+$OriginalUsagiDir = $env:USAGI_DIR
+$env:USAGI_DIR = $TempRoot
+
+try {
+    $LevelConverter = Join-Path $RepoRoot "Tools\python\lvl2vhir\lvl2vhir.py"
+    $HierarchyOut = Join-Path $OutRoot "model_instances.yml"
+    $PositionsOut = Join-Path $OutRoot "model_instances_pos.yml"
+    $InstancesOut = Join-Path $OutRoot "model_instances_inst.yml"
+
+    & python $LevelConverter --dist 10 $LevelPath $HierarchyOut $PositionsOut $InstancesOut
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+}
+finally {
+    $env:USAGI_DIR = $OriginalUsagiDir
+}
+
+foreach ($Path in @($HierarchyOut, $PositionsOut, $InstancesOut)) {
+    if (!(Test-Path $Path)) {
+        throw "Expected model instancing conversion output was not produced: $Path"
+    }
+}
+
+$Instances = Get-Content $InstancesOut -Raw
+
+if ($Instances -notmatch "Instance:\s+true") {
+    throw "Instance conversion did not mark the exported set as instanced."
+}
+if ($Instances -notmatch "Format:\s+transform") {
+    throw "Instance conversion did not emit transform instance data."
+}
+if ($Instances -notmatch "Length:\s+2") {
+    throw "Instance conversion did not emit the expected instance count."
+}
+if ($Instances -notmatch "ModelName:\s+PBRSample/PBRSample\.vmdc") {
+    throw "Instance conversion did not preserve the current .vmdc model resource name."
+}
+if ($Instances -notmatch "name:\s+PBRSampleProp\.yml") {
+    throw "Instance conversion did not preserve source entity names."
+}
+
+$NodeMatches = [regex]::Matches($Instances, "name:\s+PBRSampleProp\.yml")
+if ($NodeMatches.Count -ne 2) {
+    throw "Instance conversion emitted $($NodeMatches.Count) nodes instead of 2."
+}
+
+foreach ($Expected in @(
+    "translation:\s*\r?\n\s*-\s+-1\.0\s*\r?\n\s*-\s+2\.0\s*\r?\n\s*-\s+3\.0",
+    "translation:\s*\r?\n\s*-\s+-4\.0\s*\r?\n\s*-\s+5\.0\s*\r?\n\s*-\s+6\.0",
+    "scale:\s*\r?\n\s*-\s+1\.0\s*\r?\n\s*-\s+1\.0\s*\r?\n\s*-\s+1\.0"
+)) {
+    if ($Instances -notmatch $Expected) {
+        throw "Instance conversion output was missing expected field pattern: $Expected"
+    }
+}
+
+$ModelResource = Get-Content (Join-Path $RepoRoot "Engine\Resource\ModelResource.cpp") -Raw
+if ($ModelResource -notmatch "AddInstanceBufferInfo") {
+    throw "Model resources no longer add instanced pipeline input bindings."
+}
+if ($ModelResource -notmatch "VERTEX_INPUT_RATE_INSTANCE") {
+    throw "Model resources no longer declare an instance-rate transform stream."
+}
+
+$ModelCpp = Get-Content (Join-Path $RepoRoot "Engine\Scene\Model\Model.cpp") -Raw
+if ($ModelCpp -notmatch "pMesh->bCanInstance") {
+    throw "Model loading no longer routes instanced meshes through the instancing path."
+}
+if ($ModelCpp -notmatch "InstanceMesh") {
+    throw "Model loading no longer creates InstanceMesh render nodes."
+}
+
+$ModelInstanceRenderer = Get-Content (Join-Path $RepoRoot "Engine\Scene\Model\ModelInstanceRenderer.cpp") -Raw
+if ($ModelInstanceRenderer -notmatch "m_instanceData\.push_back") {
+    throw "Model instance renderer no longer batches instance transforms."
+}
+if ($ModelInstanceRenderer -notmatch "m_instanceBuffer\.SetContents") {
+    throw "Model instance renderer no longer uploads instance transform buffers."
+}
+
+$ModelRenderNodes = Get-Content (Join-Path $RepoRoot "Engine\Scene\Model\ModelRenderNodes.cpp") -Raw
+if ($ModelRenderNodes -notmatch "DrawIndexedEx\([^;]+uCount") {
+    throw "Model instance drawer no longer draws with the batched instance count."
+}
+if ($ModelRenderNodes -notmatch "CreateInstanceRenderer") {
+    throw "Model instance mesh no longer creates a ModelInstanceRenderer."
+}
+
+$ModelShader = Get-Content (Join-Path $RepoRoot "Data\GLSL\shaders\includes\model_transform.inc") -Raw
+if ($ModelShader -notmatch "INSTANCED") {
+    throw "Model shaders no longer compile an instanced transform path."
+}
+
+$ModelEffect = Get-Content (Join-Path $RepoRoot "Data\GLSL\effects\Model.yml") -Raw
+if ($ModelEffect -notmatch "ao_mModelMat") {
+    throw "Model effect declarations no longer expose the instanced model matrix attribute."
+}
+
+Write-Host "Model instancing smoke passed: $InstancesOut"

--- a/Tools/python/lvl2vhir/Level2Instances.py
+++ b/Tools/python/lvl2vhir/Level2Instances.py
@@ -67,14 +67,14 @@ class InstancesConverter:
             gobj = LevelEditor.Game.GameObject( obj )
             cmdlPath = EntityYaml.searchModelComponent( gobj.getURI() )
             cmdlPath = cmdlPath.replace( 'Models/', '' ) + '.vmdc'
-            if not self.hash.has_key( cmdlPath ):
+            if cmdlPath not in self.hash:
                 self.hash[cmdlPath] = {}
 
             self.hash[cmdlPath][gobj.getName()] = InstanceObject(gobj)#obj
 
     def groupInstances( self, objs ):
         indexA = 0
-        instances = objs.items()
+        instances = list(objs.items())
         for keyA, insObjA in instances:
 
             # Set group number initially

--- a/Tools/python/lvl2vhir/Level2Yaml.py
+++ b/Tools/python/lvl2vhir/Level2Yaml.py
@@ -8,10 +8,10 @@ INST_SUFFIX = '_inst'
 def createInstanceEntity( yamlPath, ext ):
     usagi_dir = os.getenv( 'USAGI_DIR' )
     f = open( usagi_dir + '/Data/' + yamlPath + ext, 'r' )
-    yamlData = yaml.load(f)
+    yamlData = yaml.safe_load(f)
     f.close
 
-    if yamlData.has_key('ModelComponent'):
+    if 'ModelComponent' in yamlData:
         yamlData.pop('ModelComponent')
 
     return yamlData
@@ -57,7 +57,7 @@ def makeEntity( obj, format, isInst ):
         else:
             # Add model component
             outputUri = path + ".vmdc"
-            outputUri = string.replace(outputUri, 'Models/', '')
+            outputUri = outputUri.replace('Models/', '')
             enti['ModelComponent'] = { 'name': outputUri }
 
         # Matrix

--- a/Tools/python/lvl2vhir/LevelEditor/Game.py
+++ b/Tools/python/lvl2vhir/LevelEditor/Game.py
@@ -227,7 +227,7 @@ class GameObject:
         self.node.attrib['{' + XmlSchemaInstance + '}type'] = type
 
     def getAttribute(self, attrName):
-        if self.node.attrib.has_key(attrName):
+        if attrName in self.node.attrib:
             return self.node.attrib[attrName]
         else:
             return None
@@ -271,32 +271,32 @@ class Level:
         return self.gameObjectFolder.find( ".//gap:gameObject[@name='%s']" % name, myNamespaces )
 
     def dump(self):
-        print self.root.tag
+        print(self.root.tag)
         folders = self.getFolders()
         depth = 0
         for folder in folders:
             self.dumpFolder( folder, depth )
 
     def dumpFolder(self, folder, depth):
-        print '----'
-        print folder.attrib['name'] + ' depth:%d' % depth
-        print '----'
+        print('----')
+        print(folder.attrib['name'] + ' depth:%d' % depth)
+        print('----')
         for obj in folder:
             if obj.tag == "{gap}folder":
                 self.dumpFolder( obj, depth + 1 )
                 continue
 
-            print obj.tag
+            print(obj.tag)
 
             gobj = GameObject(obj)
             trans = gobj.getTranslation()
             rot = gobj.getRotate()
             scale = gobj.getScale()
 
-            print "name:" + gobj.getName()
-            print "trans %f, %f, %f" % ( trans.x, trans.y, trans.z )
-            print "rot   %f, %f, %f" % ( rot.x, rot.y, rot.z )
-            print "scale %f, %f, %f" % ( scale.x, scale.y, scale.z )
+            print("name:" + gobj.getName())
+            print("trans %f, %f, %f" % ( trans.x, trans.y, trans.z ))
+            print("rot   %f, %f, %f" % ( rot.x, rot.y, rot.z ))
+            print("scale %f, %f, %f" % ( scale.x, scale.y, scale.z ))
             uri = gobj.getURI()
             if not uri == None:
-                print 'uri   ' + uri
+                print('uri   ' + uri)

--- a/Tools/python/lvlUtil/EntityYaml.py
+++ b/Tools/python/lvlUtil/EntityYaml.py
@@ -18,7 +18,7 @@ class EntityYaml:
         usagi_dir = os.getenv( 'USAGI_DIR' )
         f = open( usagi_dir + '/Data/' + yamlPath, 'r' )
 
-        yamlData = yaml.load(f)
+        yamlData = yaml.safe_load(f)
         f.close()
         return yamlData
 
@@ -35,14 +35,14 @@ class EntityYaml:
             self.inherits = vals[0] # 'vals' should be a list instance.
         else:
             if (type(vals) is dict):
-                for valKey, valValue in vals.iteritems():
+                for valKey, valValue in vals.items():
                     if not isinstance( valValue, dict):
                         self.catchValue( valKey, valValue )
                     else:
                         pass
             elif (type(vals) is list):
                 for listItem in vals:
-                    for valKey, valValue in listItem.iteritems():
+                    for valKey, valValue in listItem.items():
                         if not isinstance( valValue, dict):
                             self.catchValue( valKey, valValue )
                         else:


### PR DESCRIPTION
This adds a focused model-instancing smoke test and documentation for the
current renderer baseline, plus the small Python 3 compatibility fixes needed
to run the existing level instance converter.

Why this makes sense:

- Alex's branch already has renderer-level model batching through
  `ModelInstanceRenderer`, instanced pipelines, and `InstanceMesh` nodes.
- The porting work's explicit `Model::LoadInstanced` path conflicts with that
  baseline, so this PR validates what exists instead of replacing it.
- Keeping `.vmdf` instance-set naming and explicit loader work deferred avoids
  mixing asset naming migration with renderer validation.

What changed:

- Added `Tools/Tests/ModelInstancing/Run.ps1` to create a minimal level/entity
  fixture, run `lvl2vhir.py`, verify instance-set YAML output, and check the
  current renderer hooks.
- Added `Documents/ModelInstancing.md` documenting the validated baseline and
  deferred explicit-loader work.
- Updated the level conversion helper path for Python 3 compatibility:
  membership tests, `dict.items()`, `print()`, `yaml.safe_load`, and string
  replacement.
- Did not modify model rendering, resource loading, shaders, or asset naming.

Validation:

- `powershell -NoProfile -ExecutionPolicy Bypass -File Tools/Tests/ModelInstancing/Run.ps1` passed.
- `git diff --check`