### PR TITLE
Add resource async request foundation

### DIFF
--- a/Documents/ResourceAsyncLoading.md
+++ b/Documents/ResourceAsyncLoading.md
@@ -1,0 +1,22 @@
+# Resource Async Loading
+
+`Tools/Tests/ResourceAsyncFoundation/Run.ps1` validates the first async resource
+loading foundation slice. This PR adds state and request metadata only; it does
+not start worker threads, move resource CPU loading off-thread, or change any
+resource load call sites.
+
+The new `ResourceState` enum gives every `ResourceBase` an explicit lifecycle:
+requested, CPU loading, dependency waiting, CPU ready, queued GPU upload, GPU
+uploading, ready, failed, cancelled, and unloading. Existing `IsReady()` and
+`SetReady()` behavior remains compatible by mapping to `READY` and `REQUESTED`.
+
+`ResourceData` now owns lightweight `ResourceRequest` records. A request tracks
+the resource name, type, priority, tag, static/dynamic ownership, state,
+dependencies, and completed handle. The queue helpers deduplicate requests,
+raise priority when the same resource is queued again, select the highest
+priority requested item, and mark completion or failure.
+
+The deferred worker-loading work should build on this in later slices:
+skeletal-animation CPU preload, particle CPU data split, worker result draining,
+shutdown cancellation, and queue ownership. Those changes are intentionally
+kept out of this PR because they affect threading and resource cleanup order.

--- a/Engine/Resource/ResourceBase.h
+++ b/Engine/Resource/ResourceBase.h
@@ -35,6 +35,20 @@ namespace usg
 		HEIGHTFIELD
 	};
 
+	enum class ResourceState : uint8
+	{
+		REQUESTED = 0,
+		CPU_LOADING,
+		WAITING_DEPENDENCIES,
+		CPU_READY,
+		QUEUED_GPU_UPLOAD,
+		GPU_UPLOADING,
+		READY,
+		FAILED,
+		CANCELLED,
+		UNLOADING
+	};
+
 	class ResourceBase
 	{
 	protected:
@@ -43,7 +57,7 @@ namespace usg
 			m_nameHash = 0;
 			//m_dataHash = 0;
 			m_resourceType = eType;
-			m_bReady = false;
+			m_eState = ResourceState::REQUESTED;
 		}
 	public:
 		virtual ~ResourceBase() {}
@@ -53,8 +67,10 @@ namespace usg
 		// Support for asynchronous loading, coded to match level editor for now
 		virtual bool Init(GFXDevice* pDevice, const PakFileDecl::FileInfo* pFileHeader, const class FileDependencies* pDependencies, const void* pData) { ASSERT(false); return false; }
 		virtual void Cleanup(GFXDevice* pDevice) {}
-		bool IsReady() const { return m_bReady; }
-		void SetReady(bool bReady) { m_bReady = bReady; }
+		bool IsReady() const { return m_eState == ResourceState::READY; }
+		void SetReady(bool bReady) { m_eState = bReady ? ResourceState::READY : ResourceState::REQUESTED; }
+		ResourceState GetState() const { return m_eState; }
+		void SetState(ResourceState eState) { m_eState = eState; }
 		ResourceType GetResourceType() const { return m_resourceType; }
 
 #ifdef DEBUG_BUILD
@@ -72,7 +88,7 @@ namespace usg
 #endif
 		}
 
-		bool		m_bReady;
+		ResourceState	m_eState;
 
 	private:
 		ResourceType	m_resourceType;

--- a/Engine/Resource/ResourceData.h
+++ b/Engine/Resource/ResourceData.h
@@ -8,6 +8,7 @@
 #define USG_RESOURCE_RESOURCE_DATA_H
 
 #include "Engine/Core/stl/string.h"
+#include "Engine/Core/stl/vector.h"
 
 
 //#define DEBUG_RESOURCE_MGR
@@ -71,6 +72,47 @@ private:
 	};
 
 public:
+	struct ResourceRequestDependency
+	{
+		ResourceRequestDependency()
+			: uFileCRC(0)
+			, uUsageCRC(0)
+		{
+		}
+
+		ResourceRequestDependency(const usg::string& dependencyName, uint32 uDependencyFileCRC, uint32 uDependencyUsageCRC)
+			: name(dependencyName)
+			, uFileCRC(uDependencyFileCRC)
+			, uUsageCRC(uDependencyUsageCRC)
+		{
+		}
+
+		usg::string	name;
+		uint32		uFileCRC;
+		uint32		uUsageCRC;
+	};
+
+	struct ResourceRequest
+	{
+		ResourceRequest()
+			: eType(ResourceType::UNDEFINED)
+			, uPriority(0)
+			, uTag(0)
+			, bStatic(true)
+			, eState(ResourceState::REQUESTED)
+		{
+		}
+
+		usg::string								name;
+		ResourceType							eType;
+		uint32									uPriority;
+		uint32									uTag;
+		bool									bStatic;
+		ResourceState							eState;
+		usg::vector<ResourceRequestDependency>	dependencies;
+		BaseResHandle							resource;
+	};
+
 	ResourceData();
 	~ResourceData();
 
@@ -126,6 +168,17 @@ public:
 	BaseResHandle AddResource(const ResourceBase* pResource);
 	void AddResource(BaseResHandle resHndl);
 
+	ResourceRequest& QueueRequest(const usg::string& resName, ResourceType eType, uint32 uPriority = 0);
+	ResourceRequest* GetNextQueuedRequest();
+	const ResourceRequest* GetNextQueuedRequest() const;
+	ResourceRequest* FindRequest(const usg::string& resName, ResourceType eType);
+	const ResourceRequest* FindRequest(const usg::string& resName, ResourceType eType) const;
+	void AddRequestDependency(ResourceRequest& request, const usg::string& dependencyName, uint32 uFileCRC, uint32 uUsageCRC);
+	void SetRequestState(ResourceRequest& request, ResourceState eState);
+	void CompleteRequest(ResourceRequest& request, BaseResHandle resHandle);
+	uint32 GetRequestCount() const { return (uint32)m_requests.size(); }
+	bool HasQueuedRequests() const { return GetNextQueuedRequest() != nullptr; }
+	void ClearRequests() { m_requests.clear(); }
 
 	uint32 GetResourceCount() const { return m_resources.Size(); }
 
@@ -149,6 +202,7 @@ public:
 
 private:
 	FastPool<ResourceInfo>	m_resources;
+	usg::vector<ResourceRequest>	m_requests;
 
 };
 
@@ -190,6 +244,87 @@ inline void ResourceData::AddResource(BaseResHandle resHandle)
 	pInfo->bStatic = m_bLoadAsStatic;
 }
 
+inline ResourceData::ResourceRequest& ResourceData::QueueRequest(const usg::string& resName, ResourceType eType, uint32 uPriority)
+{
+	ResourceRequest* pRequest = FindRequest(resName, eType);
+	if (pRequest != nullptr)
+	{
+		if (uPriority > pRequest->uPriority)
+		{
+			pRequest->uPriority = uPriority;
+		}
+		return *pRequest;
+	}
+
+	ResourceRequest request;
+	request.name = resName;
+	request.eType = eType;
+	request.uPriority = uPriority;
+	request.uTag = m_uTag;
+	request.bStatic = m_bLoadAsStatic;
+	request.eState = ResourceState::REQUESTED;
+	m_requests.push_back(request);
+	return m_requests.back();
+}
+
+inline ResourceData::ResourceRequest* ResourceData::GetNextQueuedRequest()
+{
+	ResourceRequest* pNextRequest = nullptr;
+	for (uint32 i = 0; i < m_requests.size(); ++i)
+	{
+		if (m_requests[i].eState != ResourceState::REQUESTED)
+		{
+			continue;
+		}
+
+		if (pNextRequest == nullptr || m_requests[i].uPriority > pNextRequest->uPriority)
+		{
+			pNextRequest = &m_requests[i];
+		}
+	}
+
+	return pNextRequest;
+}
+
+inline const ResourceData::ResourceRequest* ResourceData::GetNextQueuedRequest() const
+{
+	return const_cast<ResourceData*>(this)->GetNextQueuedRequest();
+}
+
+inline ResourceData::ResourceRequest* ResourceData::FindRequest(const usg::string& resName, ResourceType eType)
+{
+	for (uint32 i = 0; i < m_requests.size(); ++i)
+	{
+		if (m_requests[i].name == resName && m_requests[i].eType == eType)
+		{
+			return &m_requests[i];
+		}
+	}
+
+	return nullptr;
+}
+
+inline const ResourceData::ResourceRequest* ResourceData::FindRequest(const usg::string& resName, ResourceType eType) const
+{
+	return const_cast<ResourceData*>(this)->FindRequest(resName, eType);
+}
+
+inline void ResourceData::AddRequestDependency(ResourceRequest& request, const usg::string& dependencyName, uint32 uFileCRC, uint32 uUsageCRC)
+{
+	request.dependencies.push_back(ResourceRequestDependency(dependencyName, uFileCRC, uUsageCRC));
+}
+
+inline void ResourceData::SetRequestState(ResourceRequest& request, ResourceState eState)
+{
+	request.eState = eState;
+}
+
+inline void ResourceData::CompleteRequest(ResourceRequest& request, BaseResHandle resHandle)
+{
+	request.resource = resHandle;
+	request.eState = (resHandle.get() != nullptr) ? ResourceState::READY : ResourceState::FAILED;
+}
+
 
 BaseResHandle ResourceData::GetResourceHndl(const usg::string& resName, ResourceType eType)
 {
@@ -228,4 +363,3 @@ const ResourceType* ResourceData::GetResource(const usg::string &resName, usg::R
 } // namespace usg
 
 #endif // USG_RESOURCE_RESOURCE_DATA_H
-

--- a/Tools/Tests/ResourceAsyncFoundation/Run.ps1
+++ b/Tools/Tests/ResourceAsyncFoundation/Run.ps1
@@ -1,0 +1,103 @@
+param()
+
+$ErrorActionPreference = "Stop"
+
+function Get-RepoRoot {
+    $root = (Resolve-Path $PSScriptRoot).Path
+    while ($root -and !(Test-Path (Join-Path $root "Engine\CommonProps.props"))) {
+        $parent = Split-Path $root -Parent
+        if ($parent -eq $root) {
+            break
+        }
+
+        $root = $parent
+    }
+
+    if (!$root -or !(Test-Path (Join-Path $root "Engine\CommonProps.props"))) {
+        throw "Could not locate Usagi repository root from $PSScriptRoot"
+    }
+
+    return $root
+}
+
+$RepoRoot = Get-RepoRoot
+$ResourceBase = Get-Content (Join-Path $RepoRoot "Engine\Resource\ResourceBase.h") -Raw
+$ResourceData = Get-Content (Join-Path $RepoRoot "Engine\Resource\ResourceData.h") -Raw
+$ResourceMgr = Get-Content (Join-Path $RepoRoot "Engine\Resource\ResourceMgr.cpp") -Raw
+
+foreach ($State in @(
+    "REQUESTED",
+    "CPU_LOADING",
+    "WAITING_DEPENDENCIES",
+    "CPU_READY",
+    "QUEUED_GPU_UPLOAD",
+    "GPU_UPLOADING",
+    "READY",
+    "FAILED",
+    "CANCELLED",
+    "UNLOADING"
+)) {
+    if ($ResourceBase -notmatch "\b$State\b") {
+        throw "ResourceState is missing $State"
+    }
+}
+
+if ($ResourceBase -notmatch "bool IsReady\(\) const \{ return m_eState == ResourceState::READY; \}") {
+    throw "ResourceBase::IsReady no longer maps to ResourceState::READY."
+}
+if ($ResourceBase -notmatch "void SetReady\(bool bReady\) \{ m_eState = bReady \? ResourceState::READY : ResourceState::REQUESTED; \}") {
+    throw "ResourceBase::SetReady no longer preserves legacy ready/requested behavior."
+}
+if ($ResourceBase -notmatch "ResourceState\s+m_eState") {
+    throw "ResourceBase does not store ResourceState."
+}
+
+foreach ($Expected in @(
+    "struct ResourceRequestDependency",
+    "struct ResourceRequest",
+    "QueueRequest",
+    "GetNextQueuedRequest",
+    "FindRequest",
+    "AddRequestDependency",
+    "SetRequestState",
+    "CompleteRequest",
+    "HasQueuedRequests",
+    "ClearRequests"
+)) {
+    if ($ResourceData -notmatch [regex]::Escape($Expected)) {
+        throw "ResourceData request foundation is missing: $Expected"
+    }
+}
+
+if ($ResourceData -notmatch "usg::vector<ResourceRequest>\s+m_requests") {
+    throw "ResourceData does not store queued resource requests."
+}
+
+if ($ResourceData -notmatch "if \(uPriority > pRequest->uPriority\)") {
+    throw "QueueRequest no longer raises duplicate request priority."
+}
+if ($ResourceData -notmatch "m_requests\[i\]\.eState != ResourceState::REQUESTED") {
+    throw "GetNextQueuedRequest no longer filters non-requested states."
+}
+if ($ResourceData -notmatch "m_requests\[i\]\.uPriority > pNextRequest->uPriority") {
+    throw "GetNextQueuedRequest no longer selects the highest priority request."
+}
+if ($ResourceData -notmatch "request\.dependencies\.push_back") {
+    throw "AddRequestDependency no longer records dependencies."
+}
+if ($ResourceData -notmatch "ResourceState::READY : ResourceState::FAILED") {
+    throw "CompleteRequest no longer marks success or failure from the completed handle."
+}
+
+foreach ($Deferred in @(
+    "ResourceCpuLoadWorker",
+    "RequestSkeletalAnimation",
+    "ProcessCompletedResourceLoads",
+    "MessageQueue<ResourceCpuLoadJob>"
+)) {
+    if ($ResourceMgr -match $Deferred) {
+        throw "Resource async foundation unexpectedly includes worker-loading code: $Deferred"
+    }
+}
+
+Write-Host "Resource async foundation smoke passed."


### PR DESCRIPTION
This adds the first resource async-loading foundation slice: explicit resource
lifecycle state and queued request metadata, without starting worker threads or
changing resource load call sites.

Why this makes sense:

- Later async loading work needs a reviewable state/request model before CPU
  loading moves onto worker threads.
- The change preserves existing `IsReady()` and `SetReady()` behavior while
  making intermediate lifecycle states explicit.
- Keeping worker execution, skeletal-animation preload, particle CPU splitting,
  shutdown draining, and cancellation deferred avoids mixing thread ownership
  risk into the foundation PR.

What changed:

- Added `ResourceState` with requested, CPU loading, dependency waiting, CPU
  ready, queued GPU upload, GPU uploading, ready, failed, cancelled, and
  unloading states.
- Replaced `ResourceBase`'s boolean ready storage with `ResourceState` while
  preserving the legacy ready API.
- Added `ResourceData::ResourceRequest` and dependency records with queue,
  dedupe, priority raise, lookup, state update, completion, and clear helpers.
- Added `Documents/ResourceAsyncLoading.md` describing the foundation and
  deferred worker-loading slices.
- Added `Tools/Tests/ResourceAsyncFoundation/Run.ps1` to validate the state and
  queue contract and ensure worker-loading code stays out of this PR.

Validation:

- `powershell -NoProfile -ExecutionPolicy Bypass -File Tools/Tests/ResourceAsyncFoundation/Run.ps1` passed.
- `git diff --check`