### PR TITLE
Add stable entity handle foundation

### DIFF
--- a/Documents/StableEntityIDs.md
+++ b/Documents/StableEntityIDs.md
@@ -1,0 +1,34 @@
+# Stable Entity IDs
+
+The legacy `Entity` type is a raw `ComponentEntity*`. Existing runtime code
+still uses that pointer for compatibility, but deferred work needs a value that
+can be stored and validated before it is resolved back to a live entity.
+
+## Representation
+
+`EntityHandle` is the stable value:
+
+- `uIndex`: the entity pool slot index.
+- `uGeneration`: the lifetime generation for that slot.
+
+An all-zero handle is invalid. A handle resolves only when the slot is currently
+live and its generation still matches.
+
+## Current Integration
+
+- `ComponentEntity::GetStableID()` returns the handle for a live entity.
+- `ComponentEntity::GetEntityFromStableID()` resolves a handle to a live
+  `Entity` pointer or returns `nullptr` for stale IDs.
+- `ComponentEntity::IsStableIDValid()` provides a debug-friendly validity check.
+- `Components::EntityID` still carries the legacy raw pointer in `id`, and now
+  also stores `stableId` for new code.
+
+## Migration Rule
+
+New deferred jobs, event queues, and worker-retained references should store
+`EntityHandle`. They may resolve to `Entity` only on the owning ECS thread
+immediately before use.
+
+Targeted event queues, scheduler tasks, worker mutation deferral, and frame
+threading are deferred to later PRs so this branch remains a small identity
+foundation.

--- a/Engine/Framework/ComponentEntity.cpp
+++ b/Engine/Framework/ComponentEntity.cpp
@@ -10,6 +10,7 @@
 #include "NewEntities.h"
 #include "Engine/Framework/SystemCoordinator.h"
 #include "Engine/Core/String/String_Util.h"
+#include "Engine/Core/stl/vector.h"
 #include "Engine/Core/stl/memory.h"
 #include "Engine/Framework/NewEntities.h"
 
@@ -25,6 +26,7 @@ namespace usg {
 	}
 
 static uint32 s_uEntityNum=1;
+static vector<ComponentEntity*> s_stableEntityLookup;
 uint32 ComponentEntity::g_uNumSystemTypes=0;
 ComponentEntity	*		ComponentEntity::g_hierarchy;
 FastPool< ComponentEntity >* ComponentEntity::g_pPool = nullptr;
@@ -63,6 +65,7 @@ void ComponentEntity::Reset()
 	}
 	g_hierarchy = nullptr;
 	s_pNewEntities.reset(nullptr);
+	s_stableEntityLookup.clear();
 	g_uNumSystemTypes = 0;
 	s_uEntityNum = 1;
 }
@@ -71,6 +74,7 @@ ComponentEntity::ComponentEntity() : m_pComponents(StringPointerHash<ComponentTy
 {
 	m_bActive = false;
 	m_uIndex = s_uEntityNum++;
+	m_uGeneration = 0;
 	m_fCatchupTime = 0.0f;
 	m_uOnCollisionMask = 0;
 	m_bIsInNewList = false;
@@ -134,6 +138,12 @@ void ComponentEntity::Activate()
    
     
 	m_bActive = true;
+	++m_uGeneration;
+	if (m_uGeneration == 0)
+	{
+		++m_uGeneration;
+	}
+	RegisterStableEntity(this);
 	m_fCatchupTime = 0.0f;
     
 	ComponentStats::ActivatedEntity();
@@ -223,6 +233,7 @@ void ComponentEntity::Deactivate()
 	ASSERT(m_bActive);
     
 	m_bActive = false;
+	UnregisterStableEntity(this);
     
 	ComponentStats::DeactivatedEntity();
 }
@@ -283,6 +294,7 @@ ComponentEntity* ComponentEntity::Create(ComponentEntity* parent)
 
 	EntityID* entity = GameComponents<EntityID>::Create(e);
 	entity->id = e;
+	entity->stableId = e->GetStableID();
     
 	return e;
 }
@@ -316,6 +328,42 @@ void ComponentEntity::Free(Entity e, ComponentLoadHandles& handles)
 uint32 ComponentEntity::NumEntities()
 {
 	return g_pPool == nullptr ? 0 : g_pPool->Size();
+}
+
+void ComponentEntity::RegisterStableEntity(ComponentEntity* entity)
+{
+	ASSERT(entity != nullptr);
+	if (s_stableEntityLookup.size() <= entity->m_uIndex)
+	{
+		s_stableEntityLookup.resize(entity->m_uIndex + 1, nullptr);
+	}
+	ASSERT(s_stableEntityLookup[entity->m_uIndex] == nullptr || s_stableEntityLookup[entity->m_uIndex] == entity);
+	s_stableEntityLookup[entity->m_uIndex] = entity;
+}
+
+void ComponentEntity::UnregisterStableEntity(ComponentEntity* entity)
+{
+	ASSERT(entity != nullptr);
+	if (entity->m_uIndex < s_stableEntityLookup.size() && s_stableEntityLookup[entity->m_uIndex] == entity)
+	{
+		s_stableEntityLookup[entity->m_uIndex] = nullptr;
+	}
+}
+
+Entity ComponentEntity::GetEntityFromStableID(EntityHandle id)
+{
+	if (!id.IsValid() || id.uIndex >= s_stableEntityLookup.size())
+	{
+		return nullptr;
+	}
+
+	ComponentEntity* entity = s_stableEntityLookup[id.uIndex];
+	if (!entity || !entity->IsActive() || entity->m_uGeneration != id.uGeneration)
+	{
+		return nullptr;
+	}
+
+	return entity;
 }
 
 void ComponentEntity::SetComponentBit(uint32 uBitfieldOffset, uint32 uBitfieldIndex, bool bValue)

--- a/Engine/Framework/ComponentEntity.h
+++ b/Engine/Framework/ComponentEntity.h
@@ -16,11 +16,26 @@ namespace usg
 {
 
 	struct GenericInputOutputs;
+	class ComponentEntity;
 	class NewEntities;
 	struct ComponentLoadHandles;
 	struct UnsafeComponentGetter;
 
 	class ComponentType;
+	typedef ComponentEntity* Entity;
+
+	struct EntityHandle
+	{
+		EntityHandle() : uIndex(0), uGeneration(0) {}
+		EntityHandle(uint32 uIndexIn, uint32 uGenerationIn) : uIndex(uIndexIn), uGeneration(uGenerationIn) {}
+
+		bool IsValid() const { return uIndex != 0 && uGeneration != 0; }
+		bool operator==(const EntityHandle& rhs) const { return uIndex == rhs.uIndex && uGeneration == rhs.uGeneration; }
+		bool operator!=(const EntityHandle& rhs) const { return !(*this == rhs); }
+
+		uint32 uIndex;
+		uint32 uGeneration;
+	};
 
 	class ComponentEntity : public HierearchyNode<ComponentEntity>
 	{
@@ -140,11 +155,16 @@ namespace usg
 		// DO NOT CALL EXCEPT FROM NEW ENTITIES
 		void SetInNewList(bool bInNewList) { m_bIsInNewList = bInNewList; }
 		bool GetInNewList() const { return m_bIsInNewList; }
+
+		EntityHandle GetStableID() const { return EntityHandle(m_uIndex, m_uGeneration); }
+		static Entity GetEntityFromStableID(EntityHandle id);
+		static bool IsStableIDValid(EntityHandle id) { return GetEntityFromStableID(id) != nullptr; }
 	private:
 		static NewEntities& GetNewEntities();
 
 		uint32			 m_uSpawnFrame = 0;
 		uint32           m_uIndex;
+		uint32			 m_uGeneration;
 		uint32			 m_uOnCollisionMask;
 		float            m_fCatchupTime;
 		bool             m_bChanged;
@@ -163,6 +183,8 @@ namespace usg
 		static ComponentEntity *				g_hierarchy;
 		static uint32							g_uNumSystemTypes;
 
+		static void RegisterStableEntity(ComponentEntity* entity);
+		static void UnregisterStableEntity(ComponentEntity* entity);
 		void SetComponentBit(uint32 uBitfieldOffset, uint32 uBitfieldIndex, bool bValue);
 
 		uint32 GetSystemIDFromIndex(uint32 uSysIndex) const { return uSysIndex + 1; }
@@ -171,8 +193,6 @@ namespace usg
 		void LinkComponent(ComponentType *pComp);
 		void UnlinkComponent(ComponentType *pComp);
 	};
-
-	typedef ComponentEntity* Entity;
 
 	inline Entity CreateEntity(Entity parent)
 	{
@@ -189,6 +209,7 @@ namespace usg
 		struct EntityID
 		{
 			Entity id;
+			EntityHandle stableId;
 		};
 	}
 

--- a/Tools/Tests/StableEntityHandles/Run.ps1
+++ b/Tools/Tests/StableEntityHandles/Run.ps1
@@ -1,0 +1,81 @@
+param()
+
+$ErrorActionPreference = "Stop"
+
+function Get-RepoRoot {
+    $root = (Resolve-Path $PSScriptRoot).Path
+    while ($root -and !(Test-Path (Join-Path $root "Engine\CommonProps.props"))) {
+        $parent = Split-Path $root -Parent
+        if ($parent -eq $root) {
+            break
+        }
+
+        $root = $parent
+    }
+
+    if (!$root -or !(Test-Path (Join-Path $root "Engine\CommonProps.props"))) {
+        throw "Could not locate Usagi repository root from $PSScriptRoot"
+    }
+
+    return $root
+}
+
+$RepoRoot = Get-RepoRoot
+$Header = Get-Content (Join-Path $RepoRoot "Engine\Framework\ComponentEntity.h") -Raw
+$Source = Get-Content (Join-Path $RepoRoot "Engine\Framework\ComponentEntity.cpp") -Raw
+$EventManager = Get-Content (Join-Path $RepoRoot "Engine\Framework\EventManager.h") -Raw
+$SystemCoordinator = Get-Content (Join-Path $RepoRoot "Engine\Framework\SystemCoordinator.cpp") -Raw
+
+foreach ($Expected in @(
+    "struct EntityHandle",
+    "uint32 uIndex",
+    "uint32 uGeneration",
+    "bool IsValid() const",
+    "operator==",
+    "operator!=",
+    "GetStableID",
+    "GetEntityFromStableID",
+    "IsStableIDValid",
+    "EntityHandle stableId"
+)) {
+    if ($Header -notmatch [regex]::Escape($Expected)) {
+        throw "Stable entity handle header contract is missing: $Expected"
+    }
+}
+
+foreach ($Expected in @(
+    "s_stableEntityLookup",
+    "RegisterStableEntity(this)",
+    "UnregisterStableEntity(this)",
+    "s_stableEntityLookup.clear()",
+    "entity->stableId = e->GetStableID()",
+    "entity->m_uGeneration != id.uGeneration"
+)) {
+    if ($Source -notmatch [regex]::Escape($Expected)) {
+        throw "Stable entity handle source contract is missing: $Expected"
+    }
+}
+
+if ($Source -notmatch "\+\+m_uGeneration") {
+    throw "Entity generations are not incremented on activation."
+}
+if ($Source -notmatch "if \(m_uGeneration == 0\)") {
+    throw "Entity generation wraparound no longer skips invalid zero."
+}
+if ($Source -notmatch "return nullptr") {
+    throw "Stale stable handles no longer resolve to nullptr."
+}
+
+foreach ($Deferred in @(
+    "RegisterEventWithEntity(EntityHandle",
+    "EventOnEntityBase::GetEntity",
+    "SystemScheduler",
+    "TaskRunner"
+)) {
+    $Pattern = [regex]::Escape($Deferred)
+    if ($EventManager -match $Pattern -or $SystemCoordinator -match $Pattern) {
+        throw "Stable handle foundation unexpectedly includes deferred scheduler/event work: $Deferred"
+    }
+}
+
+Write-Host "Stable entity handle smoke passed."


### PR DESCRIPTION
This adds the first ECS identity slice: stable entity handles with generation
validation, while preserving the existing raw `Entity` pointer API.

Why this makes sense:

- Later deferred events, scheduler jobs, and worker-retained references need a
  value handle before they can safely cross frame/thread boundaries.
- Keeping this PR limited to identity avoids mixing in targeted event queues,
  scheduler execution, task runners, mutation deferral, or frame threading.
- Existing runtime code can keep using `Entity`; new code can opt into
  `EntityHandle` and resolve it on the owning ECS thread.

What changed:

- Added `EntityHandle` with pool index, generation, validity, and equality
  helpers.
- Added `ComponentEntity::GetStableID`, `GetEntityFromStableID`, and
  `IsStableIDValid`.
- Added active-entity registration/unregistration and generation increments on
  activation, including zero-generation wraparound protection.
- Extended `Components::EntityID` with `stableId` while preserving the legacy
  raw pointer field.
- Added `Documents/StableEntityIDs.md` and
  `Tools/Tests/StableEntityHandles/Run.ps1`.

Validation:

- `powershell -NoProfile -ExecutionPolicy Bypass -File Tools/Tests/StableEntityHandles/Run.ps1` passed.
- `git diff --check`