### PR TITLE
Document release readiness baselines

### DIFF
--- a/Documents/PerformanceBaselines.md
+++ b/Documents/PerformanceBaselines.md
@@ -1,0 +1,39 @@
+# Performance Baselines
+
+`Tools/Tests/PerformanceBaseline/Run.ps1` is the lightweight baseline entry
+point. In this stage it records harness metadata and produces `baseline.json`
+and `baseline.md`; it does not claim stable timing numbers for native rendering,
+ECS threading, or editor launch.
+
+Default command:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File Tools\Tests\PerformanceBaseline\Run.ps1
+```
+
+The default report is useful as a reproducible inventory of the current smoke
+surface. Heavy timing suites should be added only when their underlying feature
+branches have landed and the required local environment can be detected
+reliably.
+
+## Baseline Categories
+
+- Conversion baselines: behavior tree, level conversion, entity hierarchy, and
+  resource pak exporter fixtures.
+- Build/preflight baselines: baseline build and shader package rendering
+  prerequisites.
+- Managed tooling baselines: audio, entity, particle, and preview ToolCore tests
+  once those stacked branches are reviewed.
+- Runtime baselines: model instancing, resource async, scheduler, ECS threading,
+  and render/editor smoke after the corresponding runtime PRs land.
+
+## Output Policy
+
+Baseline output belongs outside committed source files. Keep generated JSON,
+markdown, and logs under the test workspace created by the runner, and compare
+duration fields only between machines/environments that are intentionally
+comparable.
+
+When a future optimization adds a stable standalone harness, add that harness to
+the baseline runner with a clear category and prerequisites instead of folding
+it into an unrelated smoke test.

--- a/Documents/ReleaseReadiness.md
+++ b/Documents/ReleaseReadiness.md
@@ -1,0 +1,51 @@
+# Release Readiness
+
+The current readiness gate is the lightweight smoke harness under
+`Tools/Tests`. It is intended to be runnable before the heavier native runtime
+and editor PRs are all available in one branch.
+
+Default local gate:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File Tools\Tests\RunAll.ps1
+```
+
+This checks the restored harness surface and runs only suites that are expected
+to work without proprietary assets, generated native projects, Vulkan SDK setup,
+or full editor integration.
+
+Optional expanded gate:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File Tools\Tests\RunAll.ps1 -IncludeOptional
+```
+
+Use the optional gate after preparing the local environment for native/project
+generation and data conversion prerequisites.
+
+## Current Coverage
+
+- Baseline build preflight and explicit native-build prerequisite reporting.
+- Portable behavior-tree conversion fixtures.
+- Level conversion fixture coverage.
+- Entity hierarchy fixture coverage.
+- Resource pak exporter diagnostics.
+- Shader package rendering preflight.
+- Release readiness aggregation.
+- Lightweight performance baseline report generation.
+
+## Deferred Release Gates
+
+Later feature PRs add more focused gates that should become part of a final
+release checklist after those branches land:
+
+- Audio build parity and managed audio CLI integration.
+- Managed ToolCore entity and particle document tests.
+- Preview host startup and asset-load smoke.
+- Model instancing validation.
+- Resource async lifecycle validation.
+- Stable entity handle and later scheduler/threading validation.
+- Optional render/editor launch smoke on machines with graphics prerequisites.
+
+The release checklist should track what actually landed. Do not require a
+future suite from an unmerged feature branch as a default gate.

--- a/Tools/Tests/PerformanceBaseline/Run.ps1
+++ b/Tools/Tests/PerformanceBaseline/Run.ps1
@@ -26,6 +26,15 @@ Invoke-TestStep 'write baseline metadata report' {
             'ResourcePakExporter',
             'ShaderPackageRendering'
         )
+        deferredSuites = @(
+            'AudioToolBuildRules',
+            'PreviewHost',
+            'ModelInstancing',
+            'ResourceAsyncFoundation',
+            'StableEntityHandles',
+            'SystemScheduler',
+            'ECSFrameThreading'
+        )
     }
 
     $json = Join-Path $OutputDir 'baseline.json'
@@ -38,7 +47,9 @@ Invoke-TestStep 'write baseline metadata report' {
         "Generated: $($report.generatedAt)",
         '',
         'This PR 02 baseline records the smoke harness surface only.',
-        'Timing and render baselines are deferred until the relevant native suites are ported.'
+        'Timing and render baselines are deferred until the relevant native suites are ported.',
+        '',
+        'Deferred suites are recorded in baseline.json so later PRs can promote them deliberately.'
     ) | Set-Content -Encoding ASCII -Path $markdown
 
     Assert-PathExists $json

--- a/Tools/Tests/ReleaseReadiness/Run.ps1
+++ b/Tools/Tests/ReleaseReadiness/Run.ps1
@@ -18,6 +18,15 @@ $Steps = @(
     'ShaderPackageRendering'
 )
 
+$DeferredSteps = @(
+    'AudioToolReverseEngineering',
+    'AudioToolBuildRules',
+    'PreviewHost',
+    'ModelInstancing',
+    'ResourceAsyncFoundation',
+    'StableEntityHandles'
+)
+
 foreach ($step in $Steps) {
     Invoke-TestStep "release readiness step exists: $step" {
         Assert-PathExists (Join-Path $TestsRoot "$step\Run.ps1")
@@ -37,6 +46,16 @@ if ($IncludeOptional) {
 }
 else {
     Add-TestSkip 'Aggregated readiness execution is opt-in; RunAll.ps1 already invokes each suite once.'
+}
+
+foreach ($step in $DeferredSteps) {
+    $script = Join-Path $TestsRoot "$step\Run.ps1"
+    if (Test-Path -LiteralPath $script) {
+        Add-TestSkip "Deferred suite available but not part of PR 02 default readiness: $step"
+    }
+    else {
+        Add-TestSkip "Deferred suite not present in this branch: $step"
+    }
 }
 
 Complete-TestHarness


### PR DESCRIPTION
This adds release-readiness and performance-baseline guidance on top of the
lightweight PR 02 test harness, without promoting future heavy native suites
into required gates before their feature branches land.

Why this makes sense:

- The release checklist should describe what is actually runnable in the
  current branch, not require tests from deferred runtime/editor PRs.
- The performance baseline runner remains environment-friendly while recording
  which future suites should be promoted deliberately.
- Keeping this stacked on PR 02 avoids duplicating the baseline harness files.

What changed:

- Added `Documents/ReleaseReadiness.md`.
- Added `Documents/PerformanceBaselines.md`.
- Updated `Tools/Tests/ReleaseReadiness/Run.ps1` to report deferred suites
  explicitly.
- Updated `Tools/Tests/PerformanceBaseline/Run.ps1` to include deferred-suite
  metadata in `baseline.json`.

Validation:

- `powershell -NoProfile -ExecutionPolicy Bypass -File Tools/Tests/ReleaseReadiness/Run.ps1` passed, 6 passed and 7 skipped.
- `powershell -NoProfile -ExecutionPolicy Bypass -File Tools/Tests/PerformanceBaseline/Run.ps1` passed, 1 passed and 1 skipped.
- `git diff --check`