### PR TITLE
Complete managed audio bank schema parity

### DIFF
--- a/Tools/Source/UsagiTools/src/Usagi.ToolCore/Audio/AudioBank.cs
+++ b/Tools/Source/UsagiTools/src/Usagi.ToolCore/Audio/AudioBank.cs
@@ -31,6 +31,8 @@ public sealed class SoundFileDefinition
     public uint FilterCrc { get; set; }
     public List<uint> EffectCrcs { get; } = [];
     public uint RoomNameCrc { get; set; }
+    public float LowPassAttenFactor { get; set; } = 1.0f;
+    public int Stacking { get; set; }
 
     internal static float ParseFloat(string value, float fallback)
     {

--- a/Tools/Source/UsagiTools/src/Usagi.ToolCore/Audio/AudioBankValidator.cs
+++ b/Tools/Source/UsagiTools/src/Usagi.ToolCore/Audio/AudioBankValidator.cs
@@ -4,6 +4,11 @@ namespace Usagi.ToolCore.Audio;
 
 public static partial class AudioBankValidator
 {
+    private const int MaxSoundEnumNameLength = 32;
+    private const int MaxSoundFilenameLength = 128;
+    private const int MaxCrossfadeLength = 32;
+    private const int MaxNamedObjectLength = 32;
+
     public static IReadOnlyList<AudioBankDiagnostic> Validate(AudioBank bank, string? projectRoot = null)
     {
         var diagnostics = new List<AudioBankDiagnostic>();
@@ -64,9 +69,9 @@ public static partial class AudioBankValidator
             diagnostics.Add(Error($"{field}.enumName", $"Duplicate normalized sound enum name '{normalizedName}'."));
         }
 
-        if (sound.EnumName.Length > 32)
+        if (sound.EnumName.Length > MaxSoundEnumNameLength)
         {
-            diagnostics.Add(Error($"{field}.enumName", "Sound enum name exceeds nanopb max size 32."));
+            diagnostics.Add(Error($"{field}.enumName", $"Sound enum name exceeds nanopb max size {MaxSoundEnumNameLength}."));
         }
 
         if (string.IsNullOrWhiteSpace(sound.Filename))
@@ -80,9 +85,9 @@ public static partial class AudioBankValidator
                 diagnostics.Add(Error($"{field}.filename", "Sound filename must be extensionless."));
             }
 
-            if (sound.Filename.Length > 32)
+            if (sound.Filename.Length > MaxSoundFilenameLength)
             {
-                diagnostics.Add(Error($"{field}.filename", "Sound filename exceeds nanopb max size 32."));
+                diagnostics.Add(Error($"{field}.filename", $"Sound filename exceeds nanopb max size {MaxSoundFilenameLength}."));
             }
 
             if (projectRoot is not null)
@@ -112,6 +117,31 @@ public static partial class AudioBankValidator
         if (sound.Priority is < 0 or > 255)
         {
             diagnostics.Add(Error($"{field}.priority", "Priority must be between 0 and 255."));
+        }
+
+        if (sound.AudioType is < 0 or > 4)
+        {
+            diagnostics.Add(Error($"{field}.eType", "Audio type must be between 0 and 4."));
+        }
+
+        if (sound.Falloff is < 0 or > 1)
+        {
+            diagnostics.Add(Error($"{field}.eFalloff", "Audio falloff must be between 0 and 1."));
+        }
+
+        if (sound.Stacking is < 0 or > 2)
+        {
+            diagnostics.Add(Error($"{field}.eStacking", "Audio stacking must be between 0 and 2."));
+        }
+
+        if (sound.LowPassAttenFactor < 0)
+        {
+            diagnostics.Add(Error($"{field}.lowPassAttenFactor", "Low-pass attenuation factor must be non-negative."));
+        }
+
+        if (sound.Crossfade.Length > MaxCrossfadeLength)
+        {
+            diagnostics.Add(Error($"{field}.crossfade", $"Crossfade name exceeds nanopb max size {MaxCrossfadeLength}."));
         }
 
         if (sound.EffectCrcs.Count > 4)
@@ -172,9 +202,9 @@ public static partial class AudioBankValidator
         {
             diagnostics.Add(Error($"{field}.enumName", "Name is required."));
         }
-        else if (name.Length > 32)
+        else if (name.Length > MaxNamedObjectLength)
         {
-            diagnostics.Add(Error($"{field}.enumName", "Name exceeds nanopb max size 32."));
+            diagnostics.Add(Error($"{field}.enumName", $"Name exceeds nanopb max size {MaxNamedObjectLength}."));
         }
 
         if (crc == 0)

--- a/Tools/Source/UsagiTools/src/Usagi.ToolCore/Audio/AudioBankYamlParser.cs
+++ b/Tools/Source/UsagiTools/src/Usagi.ToolCore/Audio/AudioBankYamlParser.cs
@@ -22,7 +22,18 @@ public static class AudioBankYamlParser
     private static readonly IReadOnlyDictionary<string, int> AudioFilters = new Dictionary<string, int>(StringComparer.Ordinal)
     {
         ["AUDIO_FILTER_LOW_PASS"] = 0,
-        ["AUDIO_FILTER_HIGH_PASS"] = 1
+        ["AUDIO_FILTER_BAND_PASS"] = 1,
+        ["AUDIO_FILTER_HIGH_PASS"] = 2,
+        ["AUDIO_FILTER_NOTCH"] = 3,
+        ["AUDIO_FILTER_LOW_PASS_ONE_POLE"] = 4,
+        ["AUDIO_FILTER_HIGH_PASS_ONE_POLE"] = 5
+    };
+
+    private static readonly IReadOnlyDictionary<string, int> AudioStacking = new Dictionary<string, int>(StringComparer.Ordinal)
+    {
+        ["AUDIO_STACK_MANY"] = 0,
+        ["AUDIO_STACK_REPLACE"] = 1,
+        ["AUDIO_STACK_DROP"] = 2
     };
 
     private static readonly IReadOnlyDictionary<string, int> AudioEffects = new Dictionary<string, int>(StringComparer.Ordinal)
@@ -168,6 +179,12 @@ public static class AudioBankYamlParser
                 case "roomNameCRC":
                     sound.RoomNameCrc = ParseUInt(value, sound.RoomNameCrc);
                     break;
+                case "lowPassAttenFactor":
+                    sound.LowPassAttenFactor = SoundFileDefinition.ParseFloat(value, sound.LowPassAttenFactor);
+                    break;
+                case "eStacking":
+                    sound.Stacking = ParseEnumInt(value, sound.Stacking, AudioStacking);
+                    break;
             }
         }
 
@@ -289,6 +306,7 @@ public static class AudioBankYamlParser
                     room.RoomName = value;
                     break;
                 case "roomCrc":
+                case "crc":
                     room.RoomCrc = ParseUInt(value, room.RoomCrc);
                     break;
                 case "filterCrc":

--- a/Tools/Source/UsagiTools/src/Usagi.ToolCore/Audio/AudioBankYamlWriter.cs
+++ b/Tools/Source/UsagiTools/src/Usagi.ToolCore/Audio/AudioBankYamlWriter.cs
@@ -46,6 +46,8 @@ public static class AudioBankYamlWriter
             writer.AppendLine($"      filterCRC: {sound.FilterCrc}");
             WriteUIntList(writer, "effectCRCs", sound.EffectCrcs, 6);
             writer.AppendLine($"      roomNameCRC: {sound.RoomNameCrc}");
+            writer.AppendLine($"      lowPassAttenFactor: {Float(sound.LowPassAttenFactor)}");
+            writer.AppendLine($"      eStacking: {sound.Stacking}");
         }
     }
 
@@ -109,7 +111,7 @@ public static class AudioBankYamlWriter
         foreach (var room in rooms)
         {
             writer.AppendLine($"    - roomName: {Quote(room.RoomName)}");
-            writer.AppendLine($"      roomCrc: {room.RoomCrc}");
+            writer.AppendLine($"      crc: {room.RoomCrc}");
             writer.AppendLine($"      filterCrc: {room.FilterCrc}");
             WriteUIntList(writer, "effectCrcs", room.EffectCrcs, 6);
         }

--- a/Tools/Source/UsagiTools/tests/Usagi.ToolCore.Tests/Audio/FsidBuilderTests.cs
+++ b/Tools/Source/UsagiTools/tests/Usagi.ToolCore.Tests/Audio/FsidBuilderTests.cs
@@ -28,10 +28,12 @@ public sealed partial class FsidBuilderTests
               effectCRCs:
                 - 300
               roomNameCRC: 400
+              lowPassAttenFactor: 0.35
+              eStacking: AUDIO_STACK_REPLACE
           filters:
             - enumName: FILTER_LOW
               crc: 200
-              eFilter: AUDIO_FILTER_LOW_PASS
+              eFilter: AUDIO_FILTER_NOTCH
               fFrequency: 0.5
               fOneOverQ: 1.25
           reverbs:
@@ -52,7 +54,7 @@ public sealed partial class FsidBuilderTests
               roomSize: 25.0
           rooms:
             - roomName: ROOM_SMALL
-              roomCrc: 400
+              crc: 400
               filterCrc: 200
               effectCrcs:
                 - 300
@@ -160,9 +162,11 @@ public sealed partial class FsidBuilderTests
         Assert.Equal(200u, sound.FilterCrc);
         Assert.Equal([300u], sound.EffectCrcs);
         Assert.Equal(400u, sound.RoomNameCrc);
+        Assert.Equal(0.35f, sound.LowPassAttenFactor);
+        Assert.Equal(1, sound.Stacking);
 
         Assert.Equal("FILTER_LOW", bank.Filters[0].EnumName);
-        Assert.Equal(0, bank.Filters[0].FilterType);
+        Assert.Equal(3, bank.Filters[0].FilterType);
         Assert.Equal(0.5f, bank.Filters[0].Frequency);
 
         Assert.Equal("REVERB_SMALL", bank.Reverbs[0].Effect.EnumName);
@@ -183,6 +187,8 @@ public sealed partial class FsidBuilderTests
 
         Assert.Equal(original.SoundFiles[0].FilterCrc, roundTripped.SoundFiles[0].FilterCrc);
         Assert.Equal(original.SoundFiles[0].EffectCrcs, roundTripped.SoundFiles[0].EffectCrcs);
+        Assert.Equal(original.SoundFiles[0].LowPassAttenFactor, roundTripped.SoundFiles[0].LowPassAttenFactor);
+        Assert.Equal(original.SoundFiles[0].Stacking, roundTripped.SoundFiles[0].Stacking);
         Assert.Equal(original.Filters[0].OneOverQ, roundTripped.Filters[0].OneOverQ);
         Assert.Equal(original.Reverbs[0].RoomFilterHf, roundTripped.Reverbs[0].RoomFilterHf);
         Assert.Equal(original.Rooms[0].RoomCrc, roundTripped.Rooms[0].RoomCrc);
@@ -231,7 +237,12 @@ public sealed partial class FsidBuilderTests
                   volume: -1
                   minDistance: 10
                   maxDistance: 1
+                  eType: 99
+                  eFalloff: 99
                   priority: 999
+                  crossfade: 123456789012345678901234567890123
+                  lowPassAttenFactor: -1
+                  eStacking: 99
                   effectCRCs: [1, 2, 3, 4, 5]
             """);
 
@@ -241,7 +252,12 @@ public sealed partial class FsidBuilderTests
         Assert.Contains(diagnostics, diagnostic => diagnostic.Field == "soundFiles[0].filename");
         Assert.Contains(diagnostics, diagnostic => diagnostic.Field == "soundFiles[0].volume");
         Assert.Contains(diagnostics, diagnostic => diagnostic.Field == "soundFiles[0].maxDistance");
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Field == "soundFiles[0].eType");
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Field == "soundFiles[0].eFalloff");
         Assert.Contains(diagnostics, diagnostic => diagnostic.Field == "soundFiles[0].priority");
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Field == "soundFiles[0].crossfade");
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Field == "soundFiles[0].lowPassAttenFactor");
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Field == "soundFiles[0].eStacking");
         Assert.Contains(diagnostics, diagnostic => diagnostic.Field == "soundFiles[0].effectCRCs");
     }
 


### PR DESCRIPTION
## Summary

Completes the managed audio bank schema coverage that sits on top of the managed FSID builder and gated build-rule integration.

This adds managed parsing, writing, round-trip coverage, and validation for runtime fields that were still missing from the managed audio model:

- `lowPassAttenFactor`
- `eStacking`
- the full `AudioFilterType` enum range
- runtime room `crc` input, while retaining `roomCrc` compatibility for existing fixtures

It also aligns filename validation with the runtime protobuf max size and keeps legacy FSID output parity intact.

## Value

This makes the managed audio path a more practical replacement candidate: it can now accept the current audio bank shape while still proving that legacy-compatible FSID generation remains byte-for-byte stable after timestamp normalization.

## Validation

- `dotnet test Tools\Source\UsagiTools\UsagiTools.slnx`
- `powershell -NoProfile -ExecutionPolicy Bypass -File Tools\Tests\AudioToolParity\Run.ps1`
- `powershell -NoProfile -ExecutionPolicy Bypass -File Tools\Tests\AudioToolBuildRules\Run.ps1`
- `powershell -NoProfile -ExecutionPolicy Bypass -File Tools\Tests\AudioToolBuilder\Run.ps1`
- `powershell -NoProfile -ExecutionPolicy Bypass -File Tools\Tests\AudioToolIntegration\Run.ps1`