### PR TITLE
Add stable entity handle diagnostics

### DIFF
--- a/Documents/StableEntityIDs.md
+++ b/Documents/StableEntityIDs.md
@@ -19,6 +19,11 @@ live and its generation still matches.
 - `ComponentEntity::GetStableID()` returns the handle for a live entity.
 - `ComponentEntity::GetEntityFromStableID()` resolves a handle to a live
   `Entity` pointer or returns `nullptr` for stale IDs.
+- `ComponentEntity::GetEntityFromStableID(handle, &status)` also reports why a
+  handle did not resolve: invalid, out of range, empty slot, inactive entity, or
+  stale generation.
+- `ComponentEntity::GetStableIDStatusName()` returns stable diagnostic names for
+  those resolver states.
 - `ComponentEntity::IsStableIDValid()` provides a debug-friendly validity check.
 - `Components::EntityID` still carries the legacy raw pointer in `id`, and now
   also stores `stableId` for new code.

--- a/Engine/Framework/ComponentEntity.cpp
+++ b/Engine/Framework/ComponentEntity.cpp
@@ -33,6 +33,14 @@ FastPool< ComponentEntity >* ComponentEntity::g_pPool = nullptr;
 void* g_mainMem = nullptr;
 MemHeap* g_pMemHeap = nullptr;
 
+static void SetStableEntityHandleStatus(StableEntityHandleStatus* pStatus, StableEntityHandleStatus eStatus)
+{
+	if (pStatus)
+	{
+		*pStatus = eStatus;
+	}
+}
+
 void ComponentEntity::InitPool(uint32 uPoolSize)
 {
 	static const size_t alloc_size = 1024 * 2048;
@@ -350,20 +358,56 @@ void ComponentEntity::UnregisterStableEntity(ComponentEntity* entity)
 	}
 }
 
-Entity ComponentEntity::GetEntityFromStableID(EntityHandle id)
+Entity ComponentEntity::GetEntityFromStableID(EntityHandle id, StableEntityHandleStatus* pStatus)
 {
 	if (!id.IsValid() || id.uIndex >= s_stableEntityLookup.size())
 	{
+		SetStableEntityHandleStatus(pStatus, !id.IsValid() ? STABLE_ENTITY_HANDLE_INVALID : STABLE_ENTITY_HANDLE_OUT_OF_RANGE);
 		return nullptr;
 	}
 
 	ComponentEntity* entity = s_stableEntityLookup[id.uIndex];
-	if (!entity || !entity->IsActive() || entity->m_uGeneration != id.uGeneration)
+	if (!entity)
 	{
+		SetStableEntityHandleStatus(pStatus, STABLE_ENTITY_HANDLE_EMPTY_SLOT);
 		return nullptr;
 	}
 
+	if (!entity->IsActive())
+	{
+		SetStableEntityHandleStatus(pStatus, STABLE_ENTITY_HANDLE_INACTIVE);
+		return nullptr;
+	}
+
+	if (entity->m_uGeneration != id.uGeneration)
+	{
+		SetStableEntityHandleStatus(pStatus, STABLE_ENTITY_HANDLE_STALE_GENERATION);
+		return nullptr;
+	}
+
+	SetStableEntityHandleStatus(pStatus, STABLE_ENTITY_HANDLE_VALID);
 	return entity;
+}
+
+const char* ComponentEntity::GetStableIDStatusName(StableEntityHandleStatus eStatus)
+{
+	switch (eStatus)
+	{
+	case STABLE_ENTITY_HANDLE_VALID:
+		return "valid";
+	case STABLE_ENTITY_HANDLE_INVALID:
+		return "invalid";
+	case STABLE_ENTITY_HANDLE_OUT_OF_RANGE:
+		return "out_of_range";
+	case STABLE_ENTITY_HANDLE_EMPTY_SLOT:
+		return "empty_slot";
+	case STABLE_ENTITY_HANDLE_INACTIVE:
+		return "inactive";
+	case STABLE_ENTITY_HANDLE_STALE_GENERATION:
+		return "stale_generation";
+	default:
+		return "unknown";
+	}
 }
 
 void ComponentEntity::SetComponentBit(uint32 uBitfieldOffset, uint32 uBitfieldIndex, bool bValue)

--- a/Engine/Framework/ComponentEntity.h
+++ b/Engine/Framework/ComponentEntity.h
@@ -37,6 +37,16 @@ namespace usg
 		uint32 uGeneration;
 	};
 
+	enum StableEntityHandleStatus
+	{
+		STABLE_ENTITY_HANDLE_VALID,
+		STABLE_ENTITY_HANDLE_INVALID,
+		STABLE_ENTITY_HANDLE_OUT_OF_RANGE,
+		STABLE_ENTITY_HANDLE_EMPTY_SLOT,
+		STABLE_ENTITY_HANDLE_INACTIVE,
+		STABLE_ENTITY_HANDLE_STALE_GENERATION
+	};
+
 	class ComponentEntity : public HierearchyNode<ComponentEntity>
 	{
 		friend class ComponentManager;
@@ -157,8 +167,9 @@ namespace usg
 		bool GetInNewList() const { return m_bIsInNewList; }
 
 		EntityHandle GetStableID() const { return EntityHandle(m_uIndex, m_uGeneration); }
-		static Entity GetEntityFromStableID(EntityHandle id);
+		static Entity GetEntityFromStableID(EntityHandle id, StableEntityHandleStatus* pStatus = nullptr);
 		static bool IsStableIDValid(EntityHandle id) { return GetEntityFromStableID(id) != nullptr; }
+		static const char* GetStableIDStatusName(StableEntityHandleStatus eStatus);
 	private:
 		static NewEntities& GetNewEntities();
 

--- a/Tools/Tests/StableEntityHandles/Run.ps1
+++ b/Tools/Tests/StableEntityHandles/Run.ps1
@@ -33,9 +33,17 @@ foreach ($Expected in @(
     "bool IsValid() const",
     "operator==",
     "operator!=",
+    "enum StableEntityHandleStatus",
+    "STABLE_ENTITY_HANDLE_VALID",
+    "STABLE_ENTITY_HANDLE_INVALID",
+    "STABLE_ENTITY_HANDLE_OUT_OF_RANGE",
+    "STABLE_ENTITY_HANDLE_EMPTY_SLOT",
+    "STABLE_ENTITY_HANDLE_INACTIVE",
+    "STABLE_ENTITY_HANDLE_STALE_GENERATION",
     "GetStableID",
     "GetEntityFromStableID",
     "IsStableIDValid",
+    "GetStableIDStatusName",
     "EntityHandle stableId"
 )) {
     if ($Header -notmatch [regex]::Escape($Expected)) {
@@ -49,7 +57,12 @@ foreach ($Expected in @(
     "UnregisterStableEntity(this)",
     "s_stableEntityLookup.clear()",
     "entity->stableId = e->GetStableID()",
-    "entity->m_uGeneration != id.uGeneration"
+    "entity->m_uGeneration != id.uGeneration",
+    "STABLE_ENTITY_HANDLE_STALE_GENERATION",
+    "STABLE_ENTITY_HANDLE_EMPTY_SLOT",
+    "STABLE_ENTITY_HANDLE_OUT_OF_RANGE",
+    "SetStableEntityHandleStatus(pStatus, STABLE_ENTITY_HANDLE_VALID)",
+    "GetStableIDStatusName"
 )) {
     if ($Source -notmatch [regex]::Escape($Expected)) {
         throw "Stable entity handle source contract is missing: $Expected"
@@ -64,6 +77,9 @@ if ($Source -notmatch "if \(m_uGeneration == 0\)") {
 }
 if ($Source -notmatch "return nullptr") {
     throw "Stale stable handles no longer resolve to nullptr."
+}
+if ($Source -notmatch '"stale_generation"' -or $Source -notmatch '"empty_slot"' -or $Source -notmatch '"out_of_range"') {
+    throw "Stable handle diagnostics no longer expose failure status names."
 }
 
 foreach ($Deferred in @(


### PR DESCRIPTION
## Summary

Adds a narrow diagnostics follow-up to the stable entity handle foundation.

Existing callers still resolve `EntityHandle` values through `ComponentEntity::GetEntityFromStableID()` and receive a live `Entity` pointer or `nullptr`. New diagnostics can pass a `StableEntityHandleStatus*` to distinguish why resolution failed:

- invalid handle
- out-of-range slot
- empty slot
- inactive entity
- stale generation

The PR also adds stable status names for logging/debug output and extends the existing stable-handle smoke test to guard the resolver contract.

## Value

This makes stable handles more useful before scheduler or event-queue work begins. A stale handle no longer collapses into a generic null result when diagnostic code needs to explain whether the stored handle was invalid, stale, or pointed at an empty slot.

## Deferred

This intentionally does not add scheduler, event-manager, mutation-deferral, or worker-threaded frame execution changes.

## Validation

- `powershell -NoProfile -ExecutionPolicy Bypass -File Tools\Tests\StableEntityHandles\Run.ps1`
- `git diff --check`

A native component-mutation runner is not present on this single-parent PR17 stack, so this slice is validated with the strengthened stable-handle source-contract smoke.