### PR TITLE
Preserve selected HDR surface format

### DIFF
--- a/Documents/RenderingColorSpacePolicy.md
+++ b/Documents/RenderingColorSpacePolicy.md
@@ -19,6 +19,9 @@ swap-chain behavior.
   `LinearToExtended`) own final HDR/display conversion. Tests in this PR should
   validate those files and shader packaging without replacing or bypassing the
   HDR swap-chain path.
+- SDR fallback surface selection must not run after an HDR surface format has
+  already been selected. Otherwise a later SDR-compatible swap-chain format can
+  silently replace `HDR_ST2084` or `HDR_Extended` output.
 
 ## Validation
 
@@ -26,5 +29,7 @@ swap-chain behavior.
   standard sRGB transfer constants for UI/text and other SDR conversion users.
 - `Data/GLSL/effects/PostProcess.yml` should continue to package the HDR output
   effects used by the current renderer.
+- Vulkan display setup should continue to guard SDR fallback format selection
+  behind `!m_bHDR` for both supported sRGB swap-chain formats.
 - Rendering tests should prefer package/build smoke checks and small math
   invariants before touching runtime rendering code.

--- a/Engine/Graphics/Device/_vulkan/Display_ps.cpp
+++ b/Engine/Graphics/Device/_vulkan/Display_ps.cpp
@@ -349,7 +349,7 @@ void Display_ps::CreateSwapChain(GFXDevice* pDevice)
 				continue;
 			}
 
-			if(!m_bHDR && (eFormat == ColorFormat::SRGBA) || (eFormat == ColorFormat::SRGBA_SWP))
+			if(!m_bHDR && ((eFormat == ColorFormat::SRGBA) || (eFormat == ColorFormat::SRGBA_SWP)))
 			{
 				if(devicePS.GetUSGFormat(surfFormats[iBestFormat].format) != ColorFormat::SRGBA)
 				{
@@ -1061,4 +1061,3 @@ void Display_ps::Minimized(usg::GFXDevice* pDevice)
 }
 
 }
-

--- a/Tools/Tests/GammaOutput/Run.ps1
+++ b/Tools/Tests/GammaOutput/Run.ps1
@@ -37,6 +37,7 @@ $ColorSpace = Read-RequiredText (Join-Path $UsagiRoot 'Data\GLSL\shaders\include
 $PostProcess = Read-RequiredText (Join-Path $UsagiRoot 'Data\GLSL\effects\PostProcess.yml')
 $LinearToHDR = Read-RequiredText (Join-Path $UsagiRoot 'Data\GLSL\shaders\PostFX\LinearToHDR.frag')
 $LinearToST2084 = Read-RequiredText (Join-Path $UsagiRoot 'Data\GLSL\shaders\PostFX\LinearToST2084.frag')
+$VulkanDisplay = Read-RequiredText (Join-Path $UsagiRoot 'Engine\Graphics\Device\_vulkan\Display_ps.cpp')
 
 foreach ($Needle in @('0.0031308', '12.92', '1.0/2.4', '0.04045', '2.4')) {
     if (-not $ColorSpace.Contains($Needle)) {
@@ -59,6 +60,15 @@ foreach ($Needle in @('InverseTonemap', 'Hdr10', 'LinearToST2084')) {
 foreach ($Needle in @('k709to2020', 'kExpanded709to2020', 'LinearToST2084')) {
     if (-not $LinearToST2084.Contains($Needle)) {
         throw "LinearToST2084.frag no longer contains expected HDR10 token: $Needle"
+    }
+}
+
+if (-not $VulkanDisplay.Contains('if(!m_bHDR && ((eFormat == ColorFormat::SRGBA) || (eFormat == ColorFormat::SRGBA_SWP)))')) {
+    throw 'Vulkan display SDR fallback can override a selected HDR surface format.'
+}
+foreach ($Needle in @('VK_COLOR_SPACE_HDR10_ST2084_EXT', 'VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT', 'ColorCorrection::HDR_ST2084', 'ColorCorrection::HDR_Extended')) {
+    if (-not $VulkanDisplay.Contains($Needle)) {
+        throw "Vulkan display no longer contains expected HDR swap-chain token: $Needle"
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes a Vulkan swap-chain surface selection precedence bug in the current HDR path.

When HDR is allowed and an HDR-capable surface format has already been selected, the SDR fallback condition should not be able to replace it with a later sRGB swap-chain format. The old expression guarded `ColorFormat::SRGBA` with `!m_bHDR`, but `ColorFormat::SRGBA_SWP` could still match after HDR was selected because of operator precedence.

This PR parenthesizes the SDR fallback condition, documents the policy, and extends the gamma smoke to catch the regression.

## Value

This preserves Alex's HDR swap-chain direction instead of replacing it. The change keeps the selected `HDR_ST2084` or `HDR_Extended` path intact when the surface list also contains SDR-compatible formats.

## Validation

- `powershell -NoProfile -ExecutionPolicy Bypass -File Tools\Tests\GammaOutput\Run.ps1`
- `powershell -NoProfile -ExecutionPolicy Bypass -File Tools\Tests\ShaderPackageRendering\Run.ps1`
- `git diff --check`