### PR TITLE
Add entity editor workflow session

### DIFF
--- a/Tools/Source/UsagiTools/src/Usagi.ToolCore/Entities/EditableEntityDocument.cs
+++ b/Tools/Source/UsagiTools/src/Usagi.ToolCore/Entities/EditableEntityDocument.cs
@@ -63,6 +63,11 @@ public sealed class EditableEntityDocument
         History.Execute(new RemoveComponentCommand(entity, componentName));
     }
 
+    public void SetComponentField(EditableComponent component, string fieldName, object? value)
+    {
+        History.Execute(new SetComponentFieldCommand(component, fieldName, value));
+    }
+
     public string ToYaml()
     {
         return _writer.Write(Root);

--- a/Tools/Source/UsagiTools/src/Usagi.ToolCore/Entities/EntityEditCommands.cs
+++ b/Tools/Source/UsagiTools/src/Usagi.ToolCore/Entities/EntityEditCommands.cs
@@ -168,3 +168,39 @@ internal sealed class RemoveComponentCommand : ICommand
         _entity.Components.Insert(insertAt, _removedComponent);
     }
 }
+
+internal sealed class SetComponentFieldCommand : ICommand
+{
+    private readonly EditableComponent _component;
+    private readonly string _fieldName;
+    private readonly object? _newValue;
+    private readonly bool _hadOldValue;
+    private readonly object? _oldValue;
+
+    public SetComponentFieldCommand(EditableComponent component, string fieldName, object? value)
+    {
+        _component = component;
+        _fieldName = fieldName;
+        _newValue = value;
+        _hadOldValue = component.Fields.TryGetValue(fieldName, out _oldValue);
+    }
+
+    public string Description => $"Set {_component.Name}.{_fieldName}";
+
+    public void Execute()
+    {
+        _component.Fields[_fieldName] = _newValue;
+    }
+
+    public void Undo()
+    {
+        if (_hadOldValue)
+        {
+            _component.Fields[_fieldName] = _oldValue;
+        }
+        else
+        {
+            _component.Fields.Remove(_fieldName);
+        }
+    }
+}

--- a/Tools/Source/UsagiTools/src/Usagi.ToolCore/Entities/EntityEditorSession.cs
+++ b/Tools/Source/UsagiTools/src/Usagi.ToolCore/Entities/EntityEditorSession.cs
@@ -1,0 +1,169 @@
+namespace Usagi.ToolCore.Entities;
+
+public sealed class EntityEditorSession
+{
+    private readonly IReadOnlyList<string> _includeDirectories;
+
+    private EntityEditorSession(
+        string sourcePath,
+        IReadOnlyList<string> includeDirectories,
+        EditableEntityDocument document,
+        IReadOnlyDictionary<string, EntityNode> includes)
+    {
+        SourcePath = sourcePath;
+        _includeDirectories = includeDirectories;
+        Document = document;
+        Includes = includes;
+    }
+
+    public string SourcePath { get; private set; }
+    public EditableEntityDocument Document { get; private set; }
+    public IReadOnlyDictionary<string, EntityNode> Includes { get; private set; }
+    public IReadOnlyList<string> Diagnostics => Document.Diagnostics;
+    public bool IsDirty => Document.IsDirty;
+
+    public static EntityEditorSession Open(string path, IEnumerable<string>? includeDirectories = null)
+    {
+        var fullPath = Path.GetFullPath(path);
+        var includes = includeDirectories?.Select(Path.GetFullPath).ToArray() ?? [];
+        var loader = new EntityHierarchyLoader(includes);
+        var document = loader.LoadFile(fullPath);
+        return new EntityEditorSession(
+            fullPath,
+            includes,
+            EditableEntityDocument.FromReadOnly(document),
+            document.Includes);
+    }
+
+    public void Reload()
+    {
+        var loader = new EntityHierarchyLoader(_includeDirectories);
+        var document = loader.LoadFile(SourcePath);
+        Document = EditableEntityDocument.FromReadOnly(document);
+        Includes = document.Includes;
+    }
+
+    public IReadOnlyList<EntityOutlineItem> GetOutline()
+    {
+        var items = new List<EntityOutlineItem>();
+        AddOutlineItem(items, Document.Root, "", Document.Root.DisplayName, depth: 0);
+        return items;
+    }
+
+    public EditableEntityNode GetEntity(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return Document.Root;
+        }
+
+        var current = Document.Root;
+        foreach (var part in path.Split('/', StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (!int.TryParse(part, out var index) || index < 0 || index >= current.Children.Count)
+            {
+                throw new ArgumentOutOfRangeException(nameof(path), path, "Entity path does not resolve to an entity.");
+            }
+
+            current = current.Children[index];
+        }
+
+        return current;
+    }
+
+    public IReadOnlyList<EntityComponentView> GetComponents(string path)
+    {
+        return GetEntity(path)
+            .Components
+            .Select(component => new EntityComponentView(component.Name, component.Fields.Count, component.Fields))
+            .ToArray();
+    }
+
+    public IReadOnlyList<EntityIncludeView> GetIncludeViews()
+    {
+        return Includes
+            .OrderBy(pair => pair.Key, StringComparer.Ordinal)
+            .Select(pair => new EntityIncludeView(
+                pair.Key,
+                pair.Value.DisplayName,
+                pair.Value.Components.Select(component => component.Name).ToArray()))
+            .ToArray();
+    }
+
+    public void RenameEntity(string path, string newName)
+    {
+        Document.Rename(GetEntity(path), newName);
+    }
+
+    public void AddComponent(string path, string componentName, Dictionary<string, object?>? fields = null)
+    {
+        Document.AddComponent(GetEntity(path), componentName, fields);
+    }
+
+    public void SetComponentField(string path, string componentName, string fieldName, object? value)
+    {
+        var component = GetEntity(path).Components.FirstOrDefault(component => component.Name == componentName);
+        if (component is null)
+        {
+            throw new InvalidOperationException($"Entity '{path}' does not have component '{componentName}'.");
+        }
+
+        Document.SetComponentField(component, fieldName, value);
+    }
+
+    public string Save()
+    {
+        Document.Save();
+        return SourcePath;
+    }
+
+    public string SaveAs(string path)
+    {
+        var fullPath = Path.GetFullPath(path);
+        Document.SaveAs(fullPath);
+        SourcePath = fullPath;
+        Document = new EditableEntityDocument(fullPath, Document.Root, Document.Diagnostics);
+        Document.History.MarkSaved();
+        return SourcePath;
+    }
+
+    private static void AddOutlineItem(
+        List<EntityOutlineItem> items,
+        EditableEntityNode entity,
+        string path,
+        string displayPath,
+        int depth)
+    {
+        items.Add(new EntityOutlineItem(
+            path,
+            displayPath,
+            entity.DisplayName,
+            depth,
+            entity.Components.Select(component => component.Name).ToArray(),
+            entity.Inherits.ToArray()));
+
+        for (var i = 0; i < entity.Children.Count; i++)
+        {
+            var childPath = string.IsNullOrEmpty(path) ? i.ToString() : $"{path}/{i}";
+            AddOutlineItem(items, entity.Children[i], childPath, $"{displayPath}/{entity.Children[i].DisplayName}", depth + 1);
+        }
+    }
+}
+
+public sealed record EntityOutlineItem(
+    string Path,
+    string DisplayPath,
+    string DisplayName,
+    int Depth,
+    IReadOnlyList<string> Components,
+    IReadOnlyList<string> Inherits);
+
+public sealed record EntityComponentView(
+    string Name,
+    int FieldCount,
+    IReadOnlyDictionary<string, object?> Fields);
+
+public sealed record EntityIncludeView(
+    string Name,
+    string DisplayName,
+    IReadOnlyList<string> Components);

--- a/Tools/Source/UsagiTools/tests/Usagi.ToolCore.Tests/EntityEditorSessionTests.cs
+++ b/Tools/Source/UsagiTools/tests/Usagi.ToolCore.Tests/EntityEditorSessionTests.cs
@@ -1,0 +1,121 @@
+using Usagi.ToolCore.Entities;
+using Xunit;
+
+namespace Usagi.ToolCore.Tests;
+
+public sealed class EntityEditorSessionTests
+{
+    [Fact]
+    public void OpenBuildsOutlineComponentsAndIncludeViews()
+    {
+        using var fixture = EntityFixture.Create();
+
+        var session = EntityEditorSession.Open(fixture.RootEntityPath, [fixture.IncludeDirectory]);
+
+        Assert.Empty(session.Diagnostics);
+        Assert.False(session.IsDirty);
+
+        var outline = session.GetOutline();
+        Assert.Equal(["", "0"], outline.Select(item => item.Path));
+        Assert.Equal("Enemy/WeaponSocket", outline[1].DisplayPath);
+        Assert.Equal(["Identifier", "ModelComponent"], outline[0].Components);
+
+        var components = session.GetComponents("");
+        Assert.Contains(components, component =>
+            component.Name == "ModelComponent" &&
+            component.Fields["name"]?.ToString() == "Models/enemy.vmdf");
+
+        var include = Assert.Single(session.GetIncludeViews());
+        Assert.Equal("BaseEnemy", include.Name);
+        Assert.Contains("HealthComponent", include.Components);
+    }
+
+    [Fact]
+    public void EditsUseCommandHistoryAndSaveRoundTrips()
+    {
+        using var fixture = EntityFixture.Create();
+        var session = EntityEditorSession.Open(fixture.RootEntityPath, [fixture.IncludeDirectory]);
+
+        session.RenameEntity("", "EliteEnemy");
+        session.SetComponentField("", "ModelComponent", "name", "Models/elite.vmdf");
+        session.AddComponent("0", "TransformComponent", new Dictionary<string, object?> { ["x"] = 1.0 });
+
+        Assert.True(session.IsDirty);
+        Assert.Equal("EliteEnemy", session.GetEntity("").DisplayName);
+        Assert.Contains(session.GetComponents("0"), component => component.Name == "TransformComponent");
+
+        session.Document.History.Undo();
+        Assert.DoesNotContain(session.GetComponents("0"), component => component.Name == "TransformComponent");
+        session.Document.History.Redo();
+
+        session.Save();
+        Assert.False(session.IsDirty);
+
+        var reloaded = EntityEditorSession.Open(fixture.RootEntityPath, [fixture.IncludeDirectory]);
+        Assert.Equal("EliteEnemy", reloaded.GetEntity("").DisplayName);
+        Assert.Contains(reloaded.GetComponents(""), component =>
+            component.Name == "ModelComponent" &&
+            component.Fields["name"]?.ToString() == "Models/elite.vmdf");
+        Assert.Contains(reloaded.GetComponents("0"), component => component.Name == "TransformComponent");
+    }
+
+    [Fact]
+    public void MissingEntityPathIsReported()
+    {
+        using var fixture = EntityFixture.Create();
+        var session = EntityEditorSession.Open(fixture.RootEntityPath, [fixture.IncludeDirectory]);
+
+        var error = Assert.Throws<ArgumentOutOfRangeException>(() => session.GetEntity("2"));
+
+        Assert.Equal("path", error.ParamName);
+    }
+
+    private sealed class EntityFixture : IDisposable
+    {
+        private readonly DirectoryInfo _root;
+
+        private EntityFixture(DirectoryInfo root, string includeDirectory, string rootEntityPath)
+        {
+            _root = root;
+            IncludeDirectory = includeDirectory;
+            RootEntityPath = rootEntityPath;
+        }
+
+        public string IncludeDirectory { get; }
+        public string RootEntityPath { get; }
+
+        public static EntityFixture Create()
+        {
+            var root = Directory.CreateTempSubdirectory("usagi-entity-session-");
+            var includeDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "Includes"));
+            File.WriteAllText(Path.Combine(includeDirectory.FullName, "BaseEnemy.yml"), """
+Identifier:
+  name: BaseEnemy
+HealthComponent:
+  fLife: 10.0
+""");
+
+            var rootEntityPath = Path.Combine(root.FullName, "Enemy.yml");
+            File.WriteAllText(rootEntityPath, """
+Inherits:
+  - BaseEnemy
+Identifier:
+  name: Enemy
+ModelComponent:
+  name: Models/enemy.vmdf
+Children:
+  - Identifier:
+      name: WeaponSocket
+    AttachmentComponent:
+      bone: hand_r
+""");
+
+            return new EntityFixture(root, includeDirectory.FullName, rootEntityPath);
+        }
+
+        public void Dispose()
+        {
+            _root.Delete(recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a concrete entity editor workflow layer on top of the managed entity hierarchy document model.

This introduces `EntityEditorSession`, a UI-free ToolCore workflow object for:

- opening entity YAML with include directories
- exposing an entity outline with stable path IDs
- inspecting component fields and inherited include summaries
- renaming entities through command history
- adding components through command history
- updating component fields through command history
- saving and reloading round-tripped YAML

The PR also adds a command-history-backed component field update command and focused tests for open/edit/save/reload behavior.

## Value

This turns the PR09 entity document model into something an editor can actually drive without introducing a generic application shell. It proves the useful workflow boundary first: document loading, include visibility, selection paths, component display, edits, undo/redo, save, and reload.

## Deferred

This intentionally does not add runtime ECS changes, scheduler/threading work, particle UI, audio UI, or a broad managed editor shell.

## Validation

- `dotnet test Tools\Source\UsagiTools\UsagiTools.slnx`
- `powershell -NoProfile -ExecutionPolicy Bypass -File Tools\Tests\EntityHierarchy\Run.ps1`
- `git diff --check`