### PR TITLE
Add particle editor workflow session

### DIFF
--- a/Tools/Source/UsagiTools/src/Usagi.ToolCore/Particles/ParticleEditorSession.cs
+++ b/Tools/Source/UsagiTools/src/Usagi.ToolCore/Particles/ParticleEditorSession.cs
@@ -1,0 +1,243 @@
+namespace Usagi.ToolCore.Particles;
+
+public sealed class ParticleEditorSession
+{
+    private ParticleEditorSession(
+        EditableEmitterDocument? emitterDocument,
+        EditableEffectDocument? effectDocument)
+    {
+        EmitterDocument = emitterDocument;
+        EffectDocument = effectDocument;
+    }
+
+    public EditableEmitterDocument? EmitterDocument { get; private set; }
+    public EditableEffectDocument? EffectDocument { get; private set; }
+
+    public bool HasEmitter => EmitterDocument is not null;
+    public bool HasEffect => EffectDocument is not null;
+    public bool IsDirty => (EmitterDocument?.IsDirty ?? false) || (EffectDocument?.IsDirty ?? false);
+
+    public static ParticleEditorSession OpenEmitter(string path)
+    {
+        return new ParticleEditorSession(EditableEmitterDocument.Load(Path.GetFullPath(path)), null);
+    }
+
+    public static ParticleEditorSession OpenEffect(string path)
+    {
+        return new ParticleEditorSession(null, EditableEffectDocument.Load(Path.GetFullPath(path)));
+    }
+
+    public static ParticleEditorSession OpenEffectWithEmitters(
+        string effectPath,
+        string emitterDirectory)
+    {
+        var effectDocument = EditableEffectDocument.Load(Path.GetFullPath(effectPath));
+        var emitterPath = FindFirstEmitter(effectDocument.Effect, emitterDirectory);
+        var emitterDocument = emitterPath is null ? null : EditableEmitterDocument.Load(emitterPath);
+        return new ParticleEditorSession(emitterDocument, effectDocument);
+    }
+
+    public IReadOnlyList<ParticleTextureView> GetTextures()
+    {
+        var emitter = RequireEmitter();
+        return emitter.Textures
+            .Select((texture, index) => new ParticleTextureView(
+                index,
+                texture.Name,
+                texture.PatternRepeatHor,
+                texture.PatternRepeatVer,
+                texture.Animation.Mode,
+                texture.Animation.AnimIndex.ToArray(),
+                texture.Animation.AnimTimeScale))
+            .ToArray();
+    }
+
+    public IReadOnlyList<ParticleEmitterInstanceView> GetEmitterInstances()
+    {
+        var effect = RequireEffect();
+        return effect.Emitters
+            .Select((instance, index) => new ParticleEmitterInstanceView(
+                index,
+                instance.EmitterName,
+                instance.Position,
+                instance.Rotation,
+                instance.Scale,
+                instance.ParticleScale,
+                instance.ReleaseFrame))
+            .ToArray();
+    }
+
+    public ParticleEmitterSummary GetEmitterSummary()
+    {
+        var emitter = RequireEmitter();
+        return new ParticleEmitterSummary(
+            emitter.Name,
+            emitter.SourcePath,
+            emitter.Shape,
+            emitter.Type,
+            emitter.Emission.MaxParticles,
+            emitter.Textures.Count,
+            emitter.Emission.EmissionRate.Frames.FirstOrDefault()?.Value ?? 0.0f,
+            emitter.Life.Frames.FirstOrDefault()?.Value ?? 0.0f);
+    }
+
+    public ParticleEffectSummary GetEffectSummary()
+    {
+        var effect = RequireEffect();
+        return new ParticleEffectSummary(
+            effect.Name,
+            effect.SourcePath,
+            effect.PreloadCount,
+            effect.Emitters.Count);
+    }
+
+    public void SetMaxParticles(int value)
+    {
+        RequireEmitterDocument().SetMaxParticles(value);
+    }
+
+    public void SetEmitterTexture(int slot, string textureName)
+    {
+        RequireEmitterDocument().SetTexture(slot, textureName);
+    }
+
+    public void AddEmitterTexture(string textureName)
+    {
+        RequireEmitterDocument().AddTexture(textureName);
+    }
+
+    public EmitterInstance AddEffectEmitter(string emitterName)
+    {
+        return RequireEffectDocument().AddEmitter(emitterName);
+    }
+
+    public void SetEffectEmitterPosition(int index, Vec3 position)
+    {
+        var effectDocument = RequireEffectDocument();
+        effectDocument.SetEmitterPosition(GetEmitterInstance(index), position);
+    }
+
+    public void SetPreloadCount(int count)
+    {
+        RequireEffectDocument().SetPreloadCount(count);
+    }
+
+    public void SaveAll()
+    {
+        EmitterDocument?.Save();
+        EffectDocument?.Save();
+    }
+
+    public ParticleConversionPlan GetEmitterConversionPlan(string projectRoot, string? outputPath = null)
+    {
+        var emitter = RequireEmitter();
+        return CreateConversionPlan(projectRoot, emitter.SourcePath, outputPath, ".pem");
+    }
+
+    public ParticleConversionPlan GetEffectConversionPlan(string projectRoot, string? outputPath = null)
+    {
+        var effect = RequireEffect();
+        return CreateConversionPlan(projectRoot, effect.SourcePath, outputPath, ".pfx");
+    }
+
+    private EditableEmitterDocument RequireEmitterDocument() =>
+        EmitterDocument ?? throw new InvalidOperationException("No emitter document is open.");
+
+    private EditableEffectDocument RequireEffectDocument() =>
+        EffectDocument ?? throw new InvalidOperationException("No effect document is open.");
+
+    private EditableEmitter RequireEmitter() => RequireEmitterDocument().Emitter;
+
+    private EditableEffect RequireEffect() => RequireEffectDocument().Effect;
+
+    private EmitterInstance GetEmitterInstance(int index)
+    {
+        var effect = RequireEffect();
+        if (index < 0 || index >= effect.Emitters.Count)
+        {
+            throw new ArgumentOutOfRangeException(nameof(index), index, "Emitter instance index is out of range.");
+        }
+
+        return effect.Emitters[index];
+    }
+
+    private static string? FindFirstEmitter(EditableEffect effect, string emitterDirectory)
+    {
+        foreach (var instance in effect.Emitters)
+        {
+            var path = Path.Combine(emitterDirectory, instance.EmitterName + ".yml");
+            if (File.Exists(path))
+            {
+                return Path.GetFullPath(path);
+            }
+        }
+
+        return null;
+    }
+
+    private static ParticleConversionPlan CreateConversionPlan(
+        string projectRoot,
+        string sourcePath,
+        string? outputPath,
+        string extension)
+    {
+        var fullRoot = Path.GetFullPath(projectRoot);
+        var fullSource = Path.GetFullPath(sourcePath);
+        var script = Path.Combine(fullRoot, "Tools", "ruby", "yml2vpb.rb");
+        var particleSubdir = extension == ".pem" ? "Emitters" : "Effects";
+        var resolvedOutput = outputPath is null
+            ? Path.Combine(fullRoot, "_romfiles", "win", "Particle", particleSubdir, Path.GetFileNameWithoutExtension(sourcePath) + extension)
+            : Path.GetFullPath(outputPath);
+
+        return new ParticleConversionPlan(
+            fullSource,
+            resolvedOutput,
+            script,
+            [
+                "-i",
+                fullSource,
+                "-o",
+                resolvedOutput
+            ]);
+    }
+}
+
+public sealed record ParticleEmitterSummary(
+    string Name,
+    string SourcePath,
+    EmitterShape Shape,
+    ParticleType Type,
+    int MaxParticles,
+    int TextureCount,
+    float EmissionRate,
+    float Lifespan);
+
+public sealed record ParticleEffectSummary(
+    string Name,
+    string SourcePath,
+    int PreloadCount,
+    int EmitterCount);
+
+public sealed record ParticleTextureView(
+    int Slot,
+    string Name,
+    int PatternRepeatHor,
+    int PatternRepeatVer,
+    TextureAnimMode AnimationMode,
+    IReadOnlyList<int> AnimationIndices,
+    float AnimationTimeScale);
+
+public sealed record ParticleEmitterInstanceView(
+    int Index,
+    string EmitterName,
+    Vec3 Position,
+    Vec3 Rotation,
+    Vec3 Scale,
+    float ParticleScale,
+    float ReleaseFrame);
+
+public sealed record ParticleConversionPlan(
+    string SourcePath,
+    string OutputPath,
+    string ScriptPath,
+    IReadOnlyList<string> Arguments);

--- a/Tools/Source/UsagiTools/tests/Usagi.ToolCore.Tests/Particles/ParticleEditorSessionTests.cs
+++ b/Tools/Source/UsagiTools/tests/Usagi.ToolCore.Tests/Particles/ParticleEditorSessionTests.cs
@@ -1,0 +1,315 @@
+using Usagi.ToolCore.Particles;
+using Xunit;
+
+namespace Usagi.ToolCore.Tests.Particles;
+
+public sealed class ParticleEditorSessionTests
+{
+    [Fact]
+    public void OpenEmitterBuildsSummaryAndTextureViews()
+    {
+        using var fixture = ParticleFixture.Create();
+
+        var session = ParticleEditorSession.OpenEmitter(fixture.EmitterPath);
+
+        var summary = session.GetEmitterSummary();
+        Assert.Equal("multi_texture_slots", summary.Name);
+        Assert.Equal(2, summary.TextureCount);
+        Assert.Equal(64, summary.MaxParticles);
+
+        var textures = session.GetTextures();
+        Assert.Equal(["particles/base", "particles/overlay"], textures.Select(texture => texture.Name));
+        Assert.Equal(TextureAnimMode.Linear, textures[1].AnimationMode);
+        Assert.Equal([0, 1, 2, 3], textures[1].AnimationIndices);
+    }
+
+    [Fact]
+    public void EmitterEditsUseCommandHistoryAndSaveRoundTrips()
+    {
+        using var fixture = ParticleFixture.Create();
+        var session = ParticleEditorSession.OpenEmitter(fixture.EmitterPath);
+
+        session.SetMaxParticles(128);
+        session.SetEmitterTexture(1, "particles/overlay_bright");
+
+        Assert.True(session.IsDirty);
+        Assert.Equal(128, session.GetEmitterSummary().MaxParticles);
+        Assert.Equal("particles/overlay_bright", session.GetTextures()[1].Name);
+
+        session.EmitterDocument!.History.Undo();
+        Assert.Equal("particles/overlay", session.GetTextures()[1].Name);
+        session.EmitterDocument.History.Redo();
+
+        session.SaveAll();
+        Assert.False(session.IsDirty);
+
+        var reloaded = ParticleEditorSession.OpenEmitter(fixture.EmitterPath);
+        Assert.Equal(128, reloaded.GetEmitterSummary().MaxParticles);
+        Assert.Equal("particles/overlay_bright", reloaded.GetTextures()[1].Name);
+    }
+
+    [Fact]
+    public void OpenEffectWithEmittersBuildsEffectAndEmitterViews()
+    {
+        using var fixture = ParticleFixture.Create();
+
+        var session = ParticleEditorSession.OpenEffectWithEmitters(fixture.EffectPath, fixture.EmitterDirectory);
+
+        Assert.True(session.HasEffect);
+        Assert.True(session.HasEmitter);
+        Assert.Equal(1, session.GetEffectSummary().EmitterCount);
+        Assert.Equal("multi_texture_slots", session.GetEmitterInstances()[0].EmitterName);
+        Assert.Equal(2, session.GetTextures().Count);
+    }
+
+    [Fact]
+    public void EffectEditsUseCommandHistoryAndConversionPlans()
+    {
+        using var fixture = ParticleFixture.Create();
+        var session = ParticleEditorSession.OpenEffectWithEmitters(fixture.EffectPath, fixture.EmitterDirectory);
+
+        session.SetPreloadCount(3);
+        session.SetEffectEmitterPosition(0, new Vec3(1.0f, 2.0f, 3.0f));
+        session.AddEffectEmitter("secondary");
+
+        Assert.True(session.IsDirty);
+        Assert.Equal(2, session.GetEffectSummary().EmitterCount);
+        Assert.Equal(1.0f, session.GetEmitterInstances()[0].Position.X);
+
+        session.EffectDocument!.History.Undo();
+        Assert.Single(session.GetEmitterInstances());
+        session.EffectDocument.History.Redo();
+
+        var emitterPlan = session.GetEmitterConversionPlan(fixture.ProjectRoot);
+        var effectPlan = session.GetEffectConversionPlan(fixture.ProjectRoot);
+
+        Assert.EndsWith("multi_texture_slots.pem", emitterPlan.OutputPath, StringComparison.Ordinal);
+        Assert.EndsWith("multi_texture_slots.pfx", effectPlan.OutputPath, StringComparison.Ordinal);
+        Assert.Contains("yml2vpb.rb", emitterPlan.ScriptPath, StringComparison.Ordinal);
+        Assert.Contains(fixture.EmitterPath, emitterPlan.Arguments);
+    }
+
+    private sealed class ParticleFixture : IDisposable
+    {
+        private readonly DirectoryInfo _root;
+
+        private ParticleFixture(DirectoryInfo root, string emitterDirectory, string emitterPath, string effectPath)
+        {
+            _root = root;
+            ProjectRoot = root.FullName;
+            EmitterDirectory = emitterDirectory;
+            EmitterPath = emitterPath;
+            EffectPath = effectPath;
+        }
+
+        public string ProjectRoot { get; }
+        public string EmitterDirectory { get; }
+        public string EmitterPath { get; }
+        public string EffectPath { get; }
+
+        public static ParticleFixture Create()
+        {
+            var root = Directory.CreateTempSubdirectory("usagi-particle-session-");
+            var emitterDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "Data", "Particle", "Emitters"));
+            var effectDirectory = Directory.CreateDirectory(Path.Combine(root.FullName, "Data", "Particle", "Effects"));
+            Directory.CreateDirectory(Path.Combine(root.FullName, "Tools", "ruby"));
+
+            var emitterPath = Path.Combine(emitterDirectory.FullName, "multi_texture_slots.yml");
+            File.WriteAllText(emitterPath, """
+Particles.EmitterEmission:
+  blend:
+    rgbSrcFunc: 6
+    rgbDestFunc: 7
+    rgbOp: 0
+    alphaSrcFunc: 1
+    alphaDestFunc: 7
+    alphaOp: 0
+    constColor:
+      m_fR: 0.0
+      m_fG: 0.0
+      m_fB: 0.0
+      m_fA: 0.0
+    alphaTestFunc: 1
+    alphaTestReference: 0.0
+  fSoftFadeDistance: 0.5
+  sortSettings:
+    eRenderLayer: 1
+    uPriority: 5
+    bWriteDepth: false
+  textureData:
+    - name: particles/base
+      uPatternRepeatHor: 1
+      uPatternRepeatVer: 1
+      textureAnim:
+        eTexMode: 0
+        bRandomOffset: false
+        animIndex: []
+        fAnimTimeScale: 1.0
+    - name: particles/overlay
+      uPatternRepeatHor: 2
+      uPatternRepeatVer: 2
+      textureAnim:
+        eTexMode: 1
+        bRandomOffset: false
+        animIndex: [0, 1, 2, 3]
+        fAnimTimeScale: 0.25
+  emission:
+    eEmissionType: 1
+    fEmissionTime: 3.0
+    emissionRate:
+      frames:
+        - fTimeIndex: 0.0
+          fValue: 25.0
+    fReleaseInterval: 0.0
+    fReleaseIntervalRandom: 0.0
+    uMaxParticles: 64
+    vUserRotation:
+      x: 0.0
+      y: 0.0
+      z: 0.0
+  fPositionRandomness: 0.0
+  omniVelocity:
+    frames:
+      - fTimeIndex: 0.0
+        fValue: 0.0
+  dirVelocity:
+    frames:
+      - fTimeIndex: 0.0
+        fValue: 0.0
+  vVelocityDir:
+    x: 0.0
+    y: 1.0
+    z: 0.0
+  fVelocityDirConeDeg: 0.0
+  fSpeedRandomness: 0.0
+  bInheritVelocity: false
+  bLocalEffect: true
+  bCPUPositionUpdate: false
+  fDrag: 0.0
+  fGravityStrength: 0.0
+  vGravityDir:
+    x: 0.0
+    y: -1.0
+    z: 0.0
+  eParticleType: 0
+  life:
+    frames:
+      - fTimeIndex: 0.0
+        fValue: 2.0
+  fLifeRandomness: 0.0
+  vParticleCenter:
+    x: 0.5
+    y: 0.5
+  particleColor:
+    eColorMode: 0
+    cColor0:
+      m_fR: 1.0
+      m_fG: 1.0
+      m_fB: 1.0
+      m_fA: 1.0
+    cColor1:
+      m_fR: 1.0
+      m_fG: 1.0
+      m_fB: 1.0
+      m_fA: 1.0
+    cColor2:
+      m_fR: 1.0
+      m_fG: 1.0
+      m_fB: 1.0
+      m_fA: 1.0
+    fInTimeEnd: 0.0
+    fOutTimeStart: 1.0
+    fPeak: 1.0
+    uRepetitionCount: 0
+    bRandomRepetitionPos: false
+    fLerpEnvColor: 0.0
+  particleAlpha:
+    fInitialAlpha: 0.0
+    fIntermediateAlpha: 1.0
+    fEndAlpha: 0.0
+    fFinishInTime: 0.1
+    fOutStartTiming: 0.9
+  particleRotation:
+    fBaseRotation: 0.0
+    fRandomise: 0.0
+    fSpeed: 0.0
+    fSpeedRandomise: 0.0
+  particleScale:
+    standardValue:
+      frames:
+        - fTimeIndex: 0.0
+          fValue: 1.0
+    fRandomness: 0.0
+    fInitial: 1.0
+    fIntermediate: 1.0
+    fEnding: 1.0
+    fBeginScaleIn: 0.0
+    fStartScaleOut: 1.0
+  eShape: 1
+---
+Particles.EmitterShapeDetails:
+  baseShape:
+    vScale:
+      x: 1.0
+      y: 1.0
+      z: 1.0
+    vRotation:
+      x: 0.0
+      y: 0.0
+      z: 0.0
+    vPosition:
+      x: 0.0
+      y: 0.0
+      z: 0.0
+    fHollowness: 0.0
+    vVelocity:
+      x: 0.0
+      y: 0.0
+      z: 0.0
+    fSpeedRand: 0.0
+    vGravity:
+      x: 0.0
+      y: 0.0
+      z: 0.0
+    fShapeExpandVel: 0.0
+  arc:
+    fArcWidthDeg: 360.0
+    fArcStartDeg: 0.0
+    bRandomizeStartAngle: false
+  vShapeExtents:
+    x: 0.0
+    y: 0.0
+    z: 0.0
+""");
+
+            var effectPath = Path.Combine(effectDirectory.FullName, "multi_texture_slots.yml");
+            File.WriteAllText(effectPath, """
+Particles.EffectGroup:
+  emitters:
+    - emitterName: multi_texture_slots
+      vScale:
+        x: 1.0
+        y: 1.0
+        z: 1.0
+      vRotation:
+        x: 0.0
+        y: 0.0
+        z: 0.0
+      vPosition:
+        x: 0.0
+        y: 0.0
+        z: 0.0
+      fParticleScale: 1.0
+      fReleaseFrame: 0.0
+  uPreloadCount: 0
+""");
+
+            return new ParticleFixture(root, emitterDirectory.FullName, emitterPath, effectPath);
+        }
+
+        public void Dispose()
+        {
+            _root.Delete(recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a concrete particle editor workflow layer on top of the managed particle document model.

This introduces `ParticleEditorSession`, a UI-free ToolCore workflow object for:

- opening emitter and effect YAML documents
- opening an effect with its first referenced emitter
- inspecting emitter summaries and multi-texture slots
- inspecting effect emitter instances
- editing emitter particle counts and texture slots through command history
- editing effect preload count, emitter positions, and emitter references through command history
- saving open documents
- building conversion plans for `.pem` and `.pfx` outputs via `Tools/ruby/yml2vpb.rb`

The tests use a synthetic multi-texture fixture so the workflow can be reviewed on the PR10 stack without pulling in runtime particle changes.

## Value

This turns the PR10 particle document model into something an editor can actually drive while staying independent from particle runtime rendering. It proves the workflow boundary first: open, inspect, edit, undo/redo, save, reload, and prepare conversion commands.

## Deferred

This intentionally does not add particle runtime renderer changes, native preview integration, or a broad managed editor shell. The PR15 particle smoke sample remains a separate sibling validation branch; this PR is stacked on PR10 to keep the managed workflow review focused.

## Validation

- `dotnet test Tools\Source\UsagiTools\UsagiTools.slnx`
- `git diff --check`

`Tools\Tests\ParticleEditorSmoke\Run.ps1` is not present on this PR10 stack, so particle package/conversion smoke remains covered by PR15 rather than duplicated here.