### PR TITLE
Add resource async request lifecycle helpers

### DIFF
--- a/Documents/ResourceAsyncLoading.md
+++ b/Documents/ResourceAsyncLoading.md
@@ -16,6 +16,13 @@ dependencies, and completed handle. The queue helpers deduplicate requests,
 raise priority when the same resource is queued again, select the highest
 priority requested item, and mark completion or failure.
 
+The first follow-up lifecycle slice adds request transition helpers for CPU
+load, dependency wait, CPU-ready, GPU-queued, and GPU-upload states. It also
+adds cancellation, explicit failure, terminal-state checks, inflight detection,
+completed-request cleanup, and terminal-request retry behavior. This keeps the
+queue usable by later worker and GPU-upload slices without starting worker
+threads in this branch.
+
 The deferred worker-loading work should build on this in later slices:
 skeletal-animation CPU preload, particle CPU data split, worker result draining,
 shutdown cancellation, and queue ownership. Those changes are intentionally

--- a/Engine/Resource/ResourceData.h
+++ b/Engine/Resource/ResourceData.h
@@ -175,7 +175,17 @@ public:
 	const ResourceRequest* FindRequest(const usg::string& resName, ResourceType eType) const;
 	void AddRequestDependency(ResourceRequest& request, const usg::string& dependencyName, uint32 uFileCRC, uint32 uUsageCRC);
 	void SetRequestState(ResourceRequest& request, ResourceState eState);
+	void MarkRequestCpuLoading(ResourceRequest& request);
+	void MarkRequestWaitingDependencies(ResourceRequest& request);
+	void MarkRequestCpuReady(ResourceRequest& request);
+	void MarkRequestQueuedGpuUpload(ResourceRequest& request);
+	void MarkRequestGpuUploading(ResourceRequest& request);
 	void CompleteRequest(ResourceRequest& request, BaseResHandle resHandle);
+	void FailRequest(ResourceRequest& request);
+	void CancelRequest(ResourceRequest& request);
+	bool IsRequestTerminal(const ResourceRequest& request) const;
+	bool HasInflightRequests() const;
+	void ClearCompletedRequests();
 	uint32 GetRequestCount() const { return (uint32)m_requests.size(); }
 	bool HasQueuedRequests() const { return GetNextQueuedRequest() != nullptr; }
 	void ClearRequests() { m_requests.clear(); }
@@ -249,6 +259,17 @@ inline ResourceData::ResourceRequest& ResourceData::QueueRequest(const usg::stri
 	ResourceRequest* pRequest = FindRequest(resName, eType);
 	if (pRequest != nullptr)
 	{
+		if (IsRequestTerminal(*pRequest))
+		{
+			pRequest->uPriority = uPriority;
+			pRequest->uTag = m_uTag;
+			pRequest->bStatic = m_bLoadAsStatic;
+			pRequest->eState = ResourceState::REQUESTED;
+			pRequest->dependencies.clear();
+			pRequest->resource.reset();
+			return *pRequest;
+		}
+
 		if (uPriority > pRequest->uPriority)
 		{
 			pRequest->uPriority = uPriority;
@@ -319,10 +340,84 @@ inline void ResourceData::SetRequestState(ResourceRequest& request, ResourceStat
 	request.eState = eState;
 }
 
+inline void ResourceData::MarkRequestCpuLoading(ResourceRequest& request)
+{
+	SetRequestState(request, ResourceState::CPU_LOADING);
+}
+
+inline void ResourceData::MarkRequestWaitingDependencies(ResourceRequest& request)
+{
+	SetRequestState(request, ResourceState::WAITING_DEPENDENCIES);
+}
+
+inline void ResourceData::MarkRequestCpuReady(ResourceRequest& request)
+{
+	SetRequestState(request, ResourceState::CPU_READY);
+}
+
+inline void ResourceData::MarkRequestQueuedGpuUpload(ResourceRequest& request)
+{
+	SetRequestState(request, ResourceState::QUEUED_GPU_UPLOAD);
+}
+
+inline void ResourceData::MarkRequestGpuUploading(ResourceRequest& request)
+{
+	SetRequestState(request, ResourceState::GPU_UPLOADING);
+}
+
 inline void ResourceData::CompleteRequest(ResourceRequest& request, BaseResHandle resHandle)
 {
 	request.resource = resHandle;
 	request.eState = (resHandle.get() != nullptr) ? ResourceState::READY : ResourceState::FAILED;
+}
+
+inline void ResourceData::FailRequest(ResourceRequest& request)
+{
+	request.resource.reset();
+	SetRequestState(request, ResourceState::FAILED);
+}
+
+inline void ResourceData::CancelRequest(ResourceRequest& request)
+{
+	if (!IsRequestTerminal(request))
+	{
+		request.resource.reset();
+		SetRequestState(request, ResourceState::CANCELLED);
+	}
+}
+
+inline bool ResourceData::IsRequestTerminal(const ResourceRequest& request) const
+{
+	return request.eState == ResourceState::READY
+		|| request.eState == ResourceState::FAILED
+		|| request.eState == ResourceState::CANCELLED;
+}
+
+inline bool ResourceData::HasInflightRequests() const
+{
+	for (uint32 i = 0; i < m_requests.size(); ++i)
+	{
+		if (!IsRequestTerminal(m_requests[i]))
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
+inline void ResourceData::ClearCompletedRequests()
+{
+	for (uint32 i = 0; i < m_requests.size();)
+	{
+		if (IsRequestTerminal(m_requests[i]))
+		{
+			m_requests.erase(m_requests.begin() + i);
+			continue;
+		}
+
+		++i;
+	}
 }
 
 

--- a/Tools/Tests/ResourceAsyncFoundation/Run.ps1
+++ b/Tools/Tests/ResourceAsyncFoundation/Run.ps1
@@ -60,7 +60,17 @@ foreach ($Expected in @(
     "FindRequest",
     "AddRequestDependency",
     "SetRequestState",
+    "MarkRequestCpuLoading",
+    "MarkRequestWaitingDependencies",
+    "MarkRequestCpuReady",
+    "MarkRequestQueuedGpuUpload",
+    "MarkRequestGpuUploading",
     "CompleteRequest",
+    "FailRequest",
+    "CancelRequest",
+    "IsRequestTerminal",
+    "HasInflightRequests",
+    "ClearCompletedRequests",
     "HasQueuedRequests",
     "ClearRequests"
 )) {
@@ -87,6 +97,21 @@ if ($ResourceData -notmatch "request\.dependencies\.push_back") {
 }
 if ($ResourceData -notmatch "ResourceState::READY : ResourceState::FAILED") {
     throw "CompleteRequest no longer marks success or failure from the completed handle."
+}
+foreach ($Expected in @(
+    "ResourceState::CPU_LOADING",
+    "ResourceState::WAITING_DEPENDENCIES",
+    "ResourceState::CPU_READY",
+    "ResourceState::QUEUED_GPU_UPLOAD",
+    "ResourceState::GPU_UPLOADING",
+    "ResourceState::CANCELLED",
+    "m_requests.erase",
+    "pRequest->dependencies.clear()",
+    "pRequest->resource.reset()"
+)) {
+    if ($ResourceData -notmatch [regex]::Escape($Expected)) {
+        throw "Resource async lifecycle follow-up is missing: $Expected"
+    }
 }
 
 foreach ($Deferred in @(


### PR DESCRIPTION
## Summary

Adds the first resource async lifecycle follow-up on top of the request/state foundation.

This keeps the work inside `ResourceData` request ownership and adds helpers for:

- CPU loading
- dependency waiting
- CPU ready
- queued GPU upload
- GPU uploading
- explicit failure
- cancellation
- terminal-state checks
- inflight-request detection
- completed-request cleanup
- retrying a terminal request by requeueing it

It updates the async loading note and strengthens the resource async smoke test to guard the lifecycle contract.

## Value

This makes the async request queue usable by later worker and GPU-upload slices without starting threads yet. Callers can now move requests through the intended lifecycle, cancel or fail them explicitly, drain terminal requests, and retry a completed/failed/cancelled request cleanly.

## Deferred

This intentionally does not add background CPU workers, GPU upload execution, resource subclass adoption, preview-host behavior, or shutdown worker draining.

## Validation

- `powershell -NoProfile -ExecutionPolicy Bypass -File Tools\Tests\ResourceAsyncFoundation\Run.ps1`
- `git diff --check`

`Tools\Tests\ResourcePakExporter\Run.ps1` is not present on this PR16 stack; pak dependency validation remains covered by PR05 rather than duplicated here.